### PR TITLE
Make kepler daemon status exit code be 1 if daemon is not running

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-cli"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "arboard",
  "chrono",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-daemon"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-e2e"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "async-trait",
  "pretty_assertions",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-exec"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "kepler-unix",
  "libc",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-protocol"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "bincode",
  "dashmap 6.1.0",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-tests"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "chrono",
  "dashmap 5.5.3",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-unix"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "libc",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.1"
+version = "0.15.2"
 
 [profile.release]
 strip = true

--- a/kepler-cli/src/main.rs
+++ b/kepler-cli/src/main.rs
@@ -986,7 +986,7 @@ async fn handle_daemon_command(command: &DaemonCommands) -> Result<()> {
         DaemonCommands::Status => {
             if !Client::is_daemon_running(&daemon_socket).await {
                 println!("Daemon is not running");
-                return Ok(());
+                std::process::exit(1);
             }
 
             println!("Daemon is running");

--- a/kepler-e2e/tests/daemon_lifecycle_test.rs
+++ b/kepler-e2e/tests/daemon_lifecycle_test.rs
@@ -111,11 +111,58 @@ async fn test_daemon_status_when_stopped() -> E2eResult<()> {
     let output = harness.daemon_status().await?;
 
     // Status command should indicate daemon is not running
-    // (exit code might still be 0, but message should indicate not running)
     assert!(
-        output.stdout_contains("not running") || output.stderr_contains("not running") || !output.success(),
+        output.stdout_contains("not running") || output.stderr_contains("not running"),
         "Daemon status should indicate not running. stdout: {}, stderr: {}",
         output.stdout, output.stderr
+    );
+
+    // Exit code should be non-zero when daemon is not running
+    assert!(
+        !output.success(),
+        "Daemon status should exit with non-zero code when not running. exit_code: {}",
+        output.exit_code
+    );
+
+    Ok(())
+}
+
+/// Test that daemon status exits with code 0 when running and non-zero when stopped
+#[tokio::test]
+async fn test_daemon_status_exit_code() -> E2eResult<()> {
+    let mut harness = E2eHarness::new().await?;
+
+    // When daemon is not running, exit code should be non-zero
+    let output = harness.daemon_status().await?;
+    assert!(
+        !output.success(),
+        "Daemon status should exit with non-zero code when not running. exit_code: {}",
+        output.exit_code
+    );
+
+    // Start the daemon
+    harness.start_daemon().await?;
+
+    // When daemon is running, exit code should be 0
+    let output = harness.daemon_status().await?;
+    assert!(
+        output.success(),
+        "Daemon status should exit with code 0 when running. exit_code: {}, stderr: {}",
+        output.exit_code, output.stderr
+    );
+
+    // Stop the daemon
+    harness.stop_daemon().await?;
+
+    // Give time for cleanup
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // After stopping, exit code should be non-zero again
+    let output = harness.daemon_status().await?;
+    assert!(
+        !output.success(),
+        "Daemon status should exit with non-zero code after daemon is stopped. exit_code: {}",
+        output.exit_code
     );
 
     Ok(())


### PR DESCRIPTION
## What does this PR do ?

Bumps version from 0.15.1 to 0.15.2 and fixes the daemon status command to exit with code 1 when the daemon is not running instead of returning success (code 0).

## Other changes ?

Adds comprehensive end-to-end tests to verify that the daemon status command returns the correct exit codes in different scenarios - exit code 0 when the daemon is running and exit code 1 when the daemon is stopped.

## How to Test ?

Run the daemon status command when the daemon is not running and verify it exits with code 1. Start the daemon and run status again to verify it exits with code 0. The new e2e tests `test_daemon_status_when_stopped` and `test_daemon_status_exit_code` can be executed to validate this behavior automatically.