### PR TITLE
Add os.user_exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-cli"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "arboard",
  "chrono",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-daemon"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-e2e"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "async-trait",
  "pretty_assertions",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-exec"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "kepler-unix",
  "libc",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-protocol"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "bincode",
  "dashmap 6.1.0",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-tests"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "chrono",
  "dashmap 5.5.3",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-unix"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "libc",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.2"
+version = "0.15.3"
 
 [profile.release]
 strip = true

--- a/docs/lua-scripting.md
+++ b/docs/lua-scripting.md
@@ -361,6 +361,28 @@ Calling `os.getgroups()` without an argument raises an error.
 
 See [Security Model — Kepler Group Stripping](security-model.md#kepler-group-stripping) for a practical example using `os.getgroups()` to filter supplementary groups.
 
+### `os.user_exists()`
+
+Check whether a system user is resolvable via NSS (passwd/LDAP/etc.):
+
+| Function | Description |
+|----------|-------------|
+| `os.user_exists(user)` | Returns `true` if the given username or uid resolves, `false` otherwise |
+
+```yaml
+services:
+  app:
+    command: !lua |
+      if not os.user_exists("postgres") then
+        error("postgres user must exist on the host")
+      end
+      return {"/usr/bin/myapp"}
+```
+
+Accepts either a username string (`"postgres"`) or a uid as a number (`1000`) or string (`"1000"`). Calling `os.user_exists()` without an argument raises an error.
+
+Unlike `os.getgroups()`, `os.user_exists()` is a simple boolean check and is **not** subject to hardening restrictions.
+
 ---
 
 ## Sandbox Restrictions
@@ -378,6 +400,7 @@ The Lua environment provides a **restricted subset** of the standard library:
 | `json` — JSON parse/stringify | |
 | `yaml` — YAML parse/stringify | |
 | `os.getgroups` — Supplementary group query | |
+| `os.user_exists` — User existence check | |
 
 **No filesystem access**: Scripts cannot read, write, or modify files on disk.
 

--- a/kepler-daemon/src/lua/templating_runtime.rs
+++ b/kepler-daemon/src/lua/templating_runtime.rs
@@ -478,6 +478,41 @@ impl LuaEvaluator {
             })?;
             os_table.set("getgroups", getgroups_fn)?;
 
+            // os.user_exists(user) — returns true if the user is resolvable via
+            // NSS (passwd/LDAP/etc.), false otherwise. Accepts either a username
+            // string or a numeric uid (as string or number). Unlike os.getgroups,
+            // this is a simple boolean existence check and is not subject to
+            // hardening restrictions.
+            let user_exists_fn = self.lua.create_function(|_, user_spec: mlua::Value| {
+                let spec = match user_spec {
+                    mlua::Value::String(s) => s.to_str()?.to_string(),
+                    mlua::Value::Integer(i) => i.to_string(),
+                    mlua::Value::Number(n) => (n as i64).to_string(),
+                    mlua::Value::Nil => {
+                        return Err(mlua::Error::RuntimeError(
+                            "os.user_exists: expected a username or uid argument".to_string(),
+                        ));
+                    }
+                    _ => {
+                        return Err(mlua::Error::RuntimeError(
+                            "os.user_exists: expected a string or number argument".to_string(),
+                        ));
+                    }
+                };
+
+                let exists = if let Ok(uid) = spec.parse::<u32>() {
+                    nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
+                        .ok()
+                        .flatten()
+                        .is_some()
+                } else {
+                    nix::unistd::User::from_name(&spec).ok().flatten().is_some()
+                };
+
+                Ok(exists)
+            })?;
+            os_table.set("user_exists", user_exists_fn)?;
+
             // Fallback to global os table (os.clock, os.date, etc.)
             if let Ok(global_os) = self.lua.globals().get::<Table>("os") {
                 let os_meta = self.lua.create_table()?;

--- a/kepler-daemon/src/lua/templating_runtime/tests.rs
+++ b/kepler-daemon/src/lua/templating_runtime/tests.rs
@@ -1198,6 +1198,132 @@ fn test_os_getgroups_other_user_errors_hardening_strict() {
     assert!(result.is_err(), "os.getgroups('0') should error with strict hardening when owner uid is 1000");
 }
 
+// --- os.user_exists() tests ---
+
+#[test]
+fn test_os_user_exists_no_arg_errors() {
+    let eval = LuaEvaluator::new().unwrap();
+    let ctx = EvalContext::default();
+
+    let result = eval.eval::<Value>(r#"return os.user_exists()"#, &ctx, "test");
+    assert!(result.is_err(), "os.user_exists() with no argument should error");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("expected a username or uid"),
+        "Error should mention missing argument: {}",
+        err
+    );
+}
+
+#[test]
+fn test_os_user_exists_root_returns_true() {
+    let eval = LuaEvaluator::new().unwrap();
+    let ctx = EvalContext::default();
+
+    let result: Value = eval
+        .eval(r#"return os.user_exists("root")"#, &ctx, "test")
+        .unwrap();
+    assert!(matches!(result, Value::Boolean(true)), "root should exist, got: {:?}", result);
+}
+
+#[test]
+fn test_os_user_exists_uid_zero_returns_true() {
+    let eval = LuaEvaluator::new().unwrap();
+    let ctx = EvalContext::default();
+
+    // Numeric uid as string
+    let result: Value = eval
+        .eval(r#"return os.user_exists("0")"#, &ctx, "test")
+        .unwrap();
+    assert!(matches!(result, Value::Boolean(true)), "uid 0 should exist, got: {:?}", result);
+
+    // Numeric uid as number
+    let result: Value = eval
+        .eval(r#"return os.user_exists(0)"#, &ctx, "test")
+        .unwrap();
+    assert!(matches!(result, Value::Boolean(true)), "uid 0 (number) should exist, got: {:?}", result);
+}
+
+#[test]
+fn test_os_user_exists_nonexistent_returns_false() {
+    let eval = LuaEvaluator::new().unwrap();
+    let ctx = EvalContext::default();
+
+    let result: Value = eval
+        .eval(
+            r#"return os.user_exists("__kepler_nonexistent_user_xyz__")"#,
+            &ctx,
+            "test",
+        )
+        .unwrap();
+    assert!(
+        matches!(result, Value::Boolean(false)),
+        "nonexistent user should return false, got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_os_user_exists_nonexistent_uid_returns_false() {
+    let eval = LuaEvaluator::new().unwrap();
+    let ctx = EvalContext::default();
+
+    // Use a very high uid unlikely to exist
+    let result: Value = eval
+        .eval(r#"return os.user_exists(4294967290)"#, &ctx, "test")
+        .unwrap();
+    assert!(
+        matches!(result, Value::Boolean(false)),
+        "nonexistent uid should return false, got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_os_user_exists_ignores_hardening() {
+    let eval = LuaEvaluator::new().unwrap();
+    let ctx = EvalContext {
+        hardening: super::HardeningLevel::Strict,
+        owner: Some(super::OwnerEvalContext {
+            uid: 1000,
+            gid: 1000,
+            user: Some("testuser".to_string()),
+        }),
+        ..Default::default()
+    };
+
+    // Existence checks are not restricted by hardening
+    let result: Value = eval
+        .eval(r#"return os.user_exists("root")"#, &ctx, "test")
+        .unwrap();
+    assert!(
+        matches!(result, Value::Boolean(true)),
+        "os.user_exists('root') should succeed even under strict hardening"
+    );
+}
+
+#[test]
+fn test_os_user_exists_available_in_inline_expr() {
+    let eval = LuaEvaluator::new().unwrap();
+    let ctx = EvalContext::default();
+
+    let result = eval
+        .eval_inline_expr(r#"type(os.user_exists)"#, &ctx, "test")
+        .unwrap();
+    assert_eq!(result.as_str().unwrap().to_string(), "function");
+}
+
+#[test]
+fn test_os_user_exists_available_in_condition() {
+    let eval = LuaEvaluator::new().unwrap();
+    let ctx = EvalContext::default();
+
+    let result = eval
+        .eval_condition("os.user_exists('root')", &ctx)
+        .unwrap();
+    assert!(result.value, "os.user_exists('root') should be truthy in condition");
+}
+
 #[test]
 fn test_os_clock_still_works_metatable_fallback() {
     let eval = LuaEvaluator::new().unwrap();

--- a/kepler-e2e/config/owner_context_test/test_os_user_exists.kepler.yaml
+++ b/kepler-e2e/config/owner_context_test/test_os_user_exists.kepler.yaml
@@ -1,0 +1,13 @@
+services:
+  user-exists-svc:
+    command: !lua |
+      local existing = os.user_exists("testuser1")
+      local missing = os.user_exists("__kepler_nonexistent_user_xyz__")
+      local by_uid = os.user_exists(0)
+      return {
+        "sh", "-c",
+        "echo EXISTING=" .. tostring(existing) ..
+        "; echo MISSING=" .. tostring(missing) ..
+        "; echo BY_UID=" .. tostring(by_uid) ..
+        "; sleep 300"
+      }

--- a/kepler-e2e/tests/owner_context_test.rs
+++ b/kepler-e2e/tests/owner_context_test.rs
@@ -256,6 +256,52 @@ async fn test_os_getgroups_blocked_strict_other_user() -> E2eResult<()> {
     Ok(())
 }
 
+// =========================================================================
+// os.user_exists()
+// =========================================================================
+
+/// os.user_exists() returns true for existing users, false for missing ones,
+/// and accepts numeric uids as well.
+#[tokio::test]
+async fn test_os_user_exists() -> E2eResult<()> {
+    let mut harness = E2eHarness::new().await?;
+    let config_path = harness.load_config(TEST_MODULE, "test_os_user_exists")?;
+
+    harness.start_daemon().await?;
+
+    let config_str = config_path.to_str().unwrap();
+    let output = harness.run_cli_as_user("testuser1", &["-f", config_str, "start", "-d"]).await?;
+    output.assert_success();
+
+    harness
+        .wait_for_service_status(&config_path, "user-exists-svc", "running", Duration::from_secs(10))
+        .await?;
+
+    let logs = harness
+        .wait_for_log_content(&config_path, "EXISTING=", Duration::from_secs(5))
+        .await?;
+    let stdout = &logs.stdout;
+
+    assert!(
+        stdout.contains("EXISTING=true"),
+        "testuser1 should exist. stdout: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("MISSING=false"),
+        "nonexistent user should return false. stdout: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("BY_UID=true"),
+        "uid 0 (root) should exist. stdout: {}",
+        stdout
+    );
+
+    harness.stop_daemon().await?;
+    Ok(())
+}
+
 /// os.getgroups(own_user) succeeds with --hardening strict
 #[tokio::test]
 async fn test_os_getgroups_allowed_strict_self() -> E2eResult<()> {


### PR DESCRIPTION
## What does this PR do ?

Adds a new `os.user_exists()` function to the Lua scripting runtime. This function allows Lua scripts to check whether a system user is resolvable via NSS (passwd, LDAP, etc.) before launching a service. It accepts a username string (e.g. `"postgres"`), a numeric uid as a number (`1000`), or a numeric uid as a string (`"1000"`), and returns a boolean. Unlike `os.getgroups()`, this function is a simple existence check and is **not** subject to hardening restrictions.

Bumps the workspace version from `0.15.2` to `0.15.3`.

## Other changes ?

- Documents `os.user_exists()` in `docs/lua-scripting.md`, including its signature, a usage example, and a note that it is exempt from hardening restrictions.
- Adds unit tests covering: missing argument error, `"root"` and uid `0` returning `true`, nonexistent username and uid returning `false`, behavior under strict hardening, and availability in inline expressions and conditions.
- Adds an end-to-end test (`test_os_user_exists`) with a dedicated config fixture that verifies correct `true`/`false` results for an existing user, a nonexistent user, and a numeric uid lookup.

## How to Test ?

Run the unit tests:
```
cargo test -p kepler-daemon
```

Run the end-to-end test:
```
cargo test -p kepler-e2e test_os_user_exists
```