### PR TITLE
fix(orchestrator): set Failed status when restart hooks fail

### DIFF
--- a/kepler-daemon/src/orchestrator/mod.rs
+++ b/kepler-daemon/src/orchestrator/mod.rs
@@ -1908,49 +1908,81 @@ impl ServiceOrchestrator {
             }
         }
 
+        // Run the start phase. If anything fails, mirror start_single_service_with_evaluator
+        // and mark the service as Failed with a reason — otherwise the status would remain
+        // Stopped (posted by stop_service above), masking the failure.
+        if let Err(e) = self.execute_restart_start_phase(&handle, service_name).await {
+            // Write error to service stderr log so it's visible via `kepler logs`.
+            // Skip for hook errors — they already wrote to stderr in run_service_hook.
+            if !matches!(e, OrchestratorError::HookFailed(_))
+                && let Some(ref log_store) = handle.get_log_store().await {
+                    let writer = LogWriter::new(log_store, service_name, "error");
+                    writer.write(&e.to_string());
+                }
+            if let Err(err) = handle.set_service_status_with_reason(
+                service_name, ServiceStatus::Failed, None, Some(e.to_string()),
+            ).await {
+                warn!("Failed to set {} to Failed: {}", service_name, err);
+            }
+            return Err(e);
+        }
+
+        Ok(())
+    }
+
+    /// Start phase of a restart — runs after the service has been stopped.
+    ///
+    /// Split out so the caller can uniformly turn any error from this phase into
+    /// a `Failed` status with reason, rather than leaving the `Stopped` status
+    /// posted by `stop_service`.
+    async fn execute_restart_start_phase(
+        &self,
+        handle: &ConfigActorHandle,
+        service_name: &str,
+    ) -> Result<(), OrchestratorError> {
         // Increment restart count before hooks so pre_start sees the updated value
         if let Err(e) = handle.increment_restart_count(service_name).await {
             warn!("Failed to increment restart count for {}: {}", service_name, e);
         }
 
         // Re-resolve service config with updated restart_count
-        let ctx = self.re_resolve_service(&handle, service_name, None).await?;
+        let ctx = self.re_resolve_service(handle, service_name, None).await?;
 
         // Emit Start event (restart includes a start)
         handle.emit_event(service_name, ServiceEvent::Start).await;
 
         // Create new token guard before pre_start hooks
         if let Some(resolved) = ctx.resolved_config.as_ref() {
-            self.create_service_token_guard(&handle, service_name, resolved).await?;
+            self.create_service_token_guard(handle, service_name, resolved).await?;
         }
 
         // Run pre_start hook (runs on every start, including restarts)
-        if let Err(e) = self.run_service_hook(&ctx, service_name, ServiceHookType::PreStart, &None, Some(&handle))
+        if let Err(e) = self.run_service_hook(&ctx, service_name, ServiceHookType::PreStart, &None, Some(handle))
             .await
         {
-            self.revoke_service_token_guard(&handle, service_name).await;
+            self.revoke_service_token_guard(handle, service_name).await;
             return Err(e);
         }
 
         // Apply on_start log retention
-        self.apply_retention(&handle, service_name, &ctx, LifecycleEvent::Start)
+        self.apply_retention(handle, service_name, &ctx, LifecycleEvent::Start)
             .await;
 
         // Spawn the service
-        self.spawn_service(&handle, service_name, &ctx).await?;
+        self.spawn_service(handle, service_name, &ctx).await?;
 
         // Run post_start hook (after process spawned)
-        if let Err(e) = self.run_service_hook(&ctx, service_name, ServiceHookType::PostStart, &None, Some(&handle)).await {
+        if let Err(e) = self.run_service_hook(&ctx, service_name, ServiceHookType::PostStart, &None, Some(handle)).await {
             warn!("Hook post_start failed for {}: {}", service_name, e);
         }
 
         // Run post_restart hook (after restart complete)
-        if let Err(e) = self.run_service_hook(&ctx, service_name, ServiceHookType::PostRestart, &None, Some(&handle)).await {
+        if let Err(e) = self.run_service_hook(&ctx, service_name, ServiceHookType::PostRestart, &None, Some(handle)).await {
             warn!("Hook post_restart failed for {}: {}", service_name, e);
         }
 
         // Spawn auxiliary tasks (health checker, file watcher)
-        self.spawn_auxiliary_tasks(&handle, service_name, &ctx).await;
+        self.spawn_auxiliary_tasks(handle, service_name, &ctx).await;
 
         Ok(())
     }

--- a/kepler-daemon/src/orchestrator/tests.rs
+++ b/kepler-daemon/src/orchestrator/tests.rs
@@ -512,6 +512,75 @@ fn current_resolved_user() -> crate::user::ResolvedUser {
     crate::user::resolve_user(&uid.as_raw().to_string()).unwrap()
 }
 
+// ---------------------------------------------------------------------------
+// restart_single_service — Failed status on pre_start hook failure
+// ---------------------------------------------------------------------------
+
+/// Symmetric to `test_start_services_restarts_failed_service`: if the
+/// `pre_start` hook fails during a restart, the service must end up in
+/// `Failed` (with a fail_reason) — not `Stopped` (the status posted by
+/// the intermediate stop phase).
+#[tokio::test]
+async fn test_restart_single_service_sets_failed_on_pre_start_failure() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = temp_dir.path().join("kepler.yaml");
+    let config_yaml = r#"
+services:
+  svc1:
+    command: ["sleep", "60"]
+    hooks:
+      pre_start:
+        run: "exit 2"
+"#;
+    std::fs::write(&config_path, config_yaml).unwrap();
+    let kepler_state_dir = temp_dir.path().join(".kepler");
+
+    let (orch, handle) = {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: caller holds ENV_LOCK
+        unsafe { std::env::set_var("KEPLER_DAEMON_PATH", &kepler_state_dir) };
+
+        let registry = Arc::new(ConfigRegistry::new());
+        let (exit_tx, _) = mpsc::channel(32);
+        let (restart_tx, _) = mpsc::channel(32);
+        let log_notifiers: super::LogNotifiers = Arc::new(dashmap::DashMap::new());
+        let token_store = Arc::new(crate::token_store::TokenStore::new());
+        let orch = ServiceOrchestrator::new(
+            registry, exit_tx, restart_tx, log_notifiers, HardeningLevel::None, None, token_store,
+            crate::containment::ContainmentManager::detect(),
+        );
+        let handle = orch
+            .registry()
+            .get_or_create(config_path.clone(), Some(std::env::vars().collect()), None, None, None)
+            .await
+            .unwrap();
+        (orch, handle)
+    };
+
+    // Simulate a service that was running so restart's stop phase has work to do
+    // (no actual process — stop_service handles that gracefully).
+    handle.set_service_status("svc1", ServiceStatus::Running).await.unwrap();
+
+    let result = orch.restart_single_service(&config_path, "svc1").await;
+    assert!(result.is_err(), "restart should propagate the pre_start hook error, got {:?}", result);
+
+    let state = handle
+        .get_service_state("svc1")
+        .await
+        .expect("svc1 state should exist");
+    assert_eq!(
+        state.status,
+        ServiceStatus::Failed,
+        "status should be Failed after pre_start hook failure, not {:?}",
+        state.status,
+    );
+    assert!(
+        state.fail_reason.as_ref().is_some_and(|r| !r.is_empty()),
+        "fail_reason should be populated, got {:?}",
+        state.fail_reason,
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn test_inject_user_identity_sets_all_four_vars() {


### PR DESCRIPTION
## Why

A service watched by the file watcher (`restart: { watch: [...] }`) whose `pre_start` hook fails during a restart shows up as `Stopped Xm ago` in `kepler ps` instead of `Failed Xm ago (...)`. The failure reason is never surfaced — the user just sees the service vanish without knowing why.

## Summary

`restart_single_service_with_reason()` (in `kepler-daemon/.../orchestrator/mod.rs` — the path used by the file watcher and `kepler restart`) runs a restart in two phases: first `stop_service()` (which posts the `Stopped` status at the end of the stop), then a start phase (re-resolve, token guard, `pre_start`, spawn, `post_start`, `post_restart`). When a step in the start phase failed, the error was simply propagated via `?` or `return Err(e)` — no status was posted, and the service stayed on the `Stopped` set by `stop_service`.

The symmetric path on the start side, `start_single_service_with_evaluator()`, already does the right thing: it wraps the start-phase execution in a `match` that, on error, writes the message to the service's stderr log (except for `OrchestratorError::HookFailed`, which has already written its own message in `run_hook_step`) and then posts `ServiceStatus::Failed` with `fail_reason` set.

This PR aligns the restart path with that same pattern: the start phase is extracted into a new private helper `execute_restart_start_phase()` (containing the unchanged re-resolve → token guard → `pre_start` → spawn → `post_start` → `post_restart` → auxiliary tasks code), and the caller wraps its `Result` so that any error uniformly posts `Failed` + `fail_reason`.

A test symmetric to `test_start_services_restarts_failed_service` is added in `kepler-daemon/.../orchestrator/tests.rs`: `test_restart_single_service_sets_failed_on_pre_start_failure` configures a service with `pre_start: { run: "exit 2" }`, manually marks it `Running`, calls `restart_single_service()`, and asserts the final status is `Failed` with a non-empty `fail_reason`. The test was verified by stash-pop: without the fix it fails (`status: Stopped`); with the fix it passes.
