### PR TITLE
Add config path to authorizer request object parameter

### DIFF
--- a/docs/lua-authorizers.md
+++ b/docs/lua-authorizers.md
@@ -55,7 +55,21 @@ Authorizer source is wrapped as `function(request, caller) ... end`. The two arg
 | Field | Type | Description |
 |-------|------|-------------|
 | `action` | `string` | The action being performed (see [Request Params Reference](#request-params-reference)) |
+| `config_path` | `string?` | Absolute path to the config file the request targets (the CLI `-f <path>`, canonicalized). `nil` for the rare request that targets no specific config |
 | `params` | `table` | Action-specific parameters (see [Request Params Reference](#request-params-reference)) |
+
+Every authorizer-evaluated request targets a specific config, so `request.config_path`
+is populated for all of them. It is the daemon-resolved (canonicalized) path, not the
+raw string the caller typed. Example — restrict an action to a known config location:
+
+```lua
+authorize: |
+  if request.action == 'stop'
+    and request.config_path == '/etc/kepler/critical.kepler.yaml' then
+    return false
+  end
+  return true
+```
 
 ### The `caller` Table
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -314,7 +314,7 @@ Authorizers can be defined on ACL user/group rules (`authorize` field) and on se
 2. **User ACL authorizer** (if the caller's UID matches a user rule with `authorize`)
 3. **Group ACL authorizers** (all matching group rules with `authorize`, sorted by GID)
 
-Each authorizer receives two read-only tables — `request` (with `action` and `params`) and `caller` (with `uid`, `gid`, `username`, `groups`, `token`):
+Each authorizer receives two read-only tables — `request` (with `action`, `config_path`, and `params`) and `caller` (with `uid`, `gid`, `username`, `groups`, `token`):
 
 ```yaml
 kepler:
@@ -341,7 +341,7 @@ Key properties:
 - **Static rights are checked first** — if the caller lacks the right, the authorizer never runs
 - **Root bypasses authorizers** — root is never subject to authorizer checks
 
-See [Lua Authorizers](lua-authorizers.md) for the full reference: per-action `request.params` fields, sandbox constraints, shared code, and aliases.
+See [Lua Authorizers](lua-authorizers.md) for the full reference: the `request.config_path` field, per-action `request.params` fields, sandbox constraints, shared code, and aliases.
 
 ---
 

--- a/kepler-daemon/src/acl/tests.rs
+++ b/kepler-daemon/src/acl/tests.rs
@@ -556,3 +556,117 @@ fn base_and_sub_right_together_allows_feature() {
     };
     assert!(resolved.check_access(1000, 1000, &req).is_ok());
 }
+
+// ---------------------------------------------------------------------------
+// Authorizer integration: `request.config_path` flows from Request → decision
+// ---------------------------------------------------------------------------
+
+/// Build an AclConfig with a single user-scoped Lua authorizer.
+fn make_acl_with_authorizer(uid: u32, rights: Vec<&str>, authorize: &str) -> AclConfig {
+    let mut users = HashMap::new();
+    users.insert(
+        uid.to_string(),
+        AclRule {
+            allow: rights.into_iter().map(String::from).collect(),
+            authorize: Some(authorize.to_string()),
+        },
+    );
+    AclConfig {
+        lua: None,
+        aliases: HashMap::new(),
+        users,
+        groups: HashMap::new(),
+    }
+}
+
+/// Build a `Request::Start` targeting a specific config path.
+fn start_request(config_path: &str) -> Request {
+    Request::Start {
+        config_path: config_path.into(),
+        services: vec![],
+        sys_env: None,
+        no_deps: false,
+        override_envs: None,
+        hardening: None,
+        define_flags: None,
+        follow: false,
+    }
+}
+
+/// Drive the full path main.rs uses: build the authorizer context from a real
+/// Request, then evaluate the compiled ACL authorizers against it.
+async fn run_authorizers(acl: &ResolvedAcl, uid: u32, gid: u32, request: &Request) -> Result<(), String> {
+    let context = crate::lua::acl_runtime::build_authorizer_context(
+        request,
+        uid,
+        gid,
+        None,
+        vec![gid],
+        false,
+    )
+    .expect("request should produce an authorizer context");
+    acl.check_authorizers(uid, gid, None, context).await
+}
+
+#[tokio::test]
+async fn authorizer_allows_when_config_path_matches() {
+    // Authorizer only allows requests targeting the app config by path.
+    let acl_cfg = make_acl_with_authorizer(
+        1000,
+        vec!["start"],
+        "return request.config_path == '/etc/kepler/app.kepler.yaml'",
+    );
+    let mut acl = ResolvedAcl::from_config(&acl_cfg).unwrap();
+    acl.init_authorizers().unwrap();
+
+    let req = start_request("/etc/kepler/app.kepler.yaml");
+    assert!(
+        run_authorizers(&acl, 1000, 1000, &req).await.is_ok(),
+        "authorizer should allow when request.config_path matches"
+    );
+}
+
+#[tokio::test]
+async fn authorizer_denies_when_config_path_mismatches() {
+    // Same authorizer, but the request targets a different config.
+    let acl_cfg = make_acl_with_authorizer(
+        1000,
+        vec!["start"],
+        "return request.config_path == '/etc/kepler/app.kepler.yaml'",
+    );
+    let mut acl = ResolvedAcl::from_config(&acl_cfg).unwrap();
+    acl.init_authorizers().unwrap();
+
+    let req = start_request("/etc/kepler/other.kepler.yaml");
+    assert!(
+        run_authorizers(&acl, 1000, 1000, &req).await.is_err(),
+        "authorizer should deny when request.config_path does not match"
+    );
+}
+
+#[tokio::test]
+async fn authorizer_sees_config_path_suffix() {
+    // A realistic authorizer that branches on a path property rather than an
+    // exact match (paths are deployment-specific).
+    let acl_cfg = make_acl_with_authorizer(
+        1000,
+        vec!["start"],
+        "return request.config_path ~= nil \
+            and string.match(request.config_path, '%.kepler%.yaml$') ~= nil",
+    );
+    let mut acl = ResolvedAcl::from_config(&acl_cfg).unwrap();
+    acl.init_authorizers().unwrap();
+
+    assert!(
+        run_authorizers(&acl, 1000, 1000, &start_request("/srv/web.kepler.yaml"))
+            .await
+            .is_ok(),
+        "authorizer should allow a config_path ending in .kepler.yaml"
+    );
+    assert!(
+        run_authorizers(&acl, 1000, 1000, &start_request("/srv/web.txt"))
+            .await
+            .is_err(),
+        "authorizer should deny a config_path with an unexpected suffix"
+    );
+}

--- a/kepler-daemon/src/lua/acl_runtime.rs
+++ b/kepler-daemon/src/lua/acl_runtime.rs
@@ -89,6 +89,8 @@ pub struct AuthorizerContext {
     pub is_token: bool,
     /// Request-specific parameters (includes `services`).
     pub params: HashMap<String, ParamValue>,
+    /// Config file path the request targets (`-f <path>`), if any.
+    pub config_path: Option<String>,
 }
 
 /// Simple value type for authorizer parameters.
@@ -158,6 +160,9 @@ fn compile_authorizer(lua: &Lua, source: &str) -> LuaResult<mlua::RegistryKey> {
 fn build_request_table(lua: &Lua, ctx: &AuthorizerContext) -> LuaResult<LuaTable> {
     let tbl = lua.create_table()?;
     tbl.set("action", ctx.action)?;
+    if let Some(ref path) = ctx.config_path {
+        tbl.set("config_path", path.as_str())?;
+    }
 
     // params
     let params = lua.create_table()?;
@@ -447,6 +452,35 @@ impl AclLuaHandle {
 ///
 /// Returns `None` for rights-free requests (Ping, ListConfigs, etc.) since
 /// those never reach the authorizer.
+/// Extract the targeted config file path from a request, if it carries one.
+fn request_config_path(request: &Request) -> Option<String> {
+    use Request::*;
+    let path = match request {
+        Start { config_path, .. }
+        | Run { config_path, .. }
+        | Stop { config_path, .. }
+        | Restart { config_path, .. }
+        | Recreate { config_path, .. }
+        | LogsStream { config_path, .. }
+        | SubscribeLogs { config_path, .. }
+        | Subscribe { config_path, .. }
+        | Inspect { config_path, .. }
+        | CheckQuiescence { config_path, .. }
+        | CheckReadiness { config_path, .. }
+        | UserRights { config_path, .. }
+        | MonitorMetrics { config_path, .. } => config_path,
+        Status {
+            config_path: Some(path),
+        } => path,
+        Status { config_path: None }
+        | Shutdown
+        | Ping
+        | ListConfigs
+        | Prune { .. } => return None,
+    };
+    Some(path.to_string_lossy().into_owned())
+}
+
 pub fn build_authorizer_context(
     request: &Request,
     uid: u32,
@@ -586,6 +620,7 @@ pub fn build_authorizer_context(
         groups,
         is_token,
         params,
+        config_path: request_config_path(request),
     })
 }
 

--- a/kepler-daemon/src/lua/acl_runtime/tests.rs
+++ b/kepler-daemon/src/lua/acl_runtime/tests.rs
@@ -11,6 +11,7 @@ fn make_context(action: &'static str) -> AuthorizerContext {
         groups: vec![1000],
         is_token: false,
         params,
+        config_path: Some("/etc/kepler/app.kepler".into()),
     }
 }
 
@@ -332,6 +333,37 @@ fn context_from_start_request() {
     assert!(matches!(ctx.params.get("no_deps"), Some(ParamValue::Bool(true))));
     assert!(matches!(ctx.params.get("hardening"), Some(ParamValue::String(s)) if s == "strict"));
     assert!(matches!(ctx.params.get("override_envs"), Some(ParamValue::StringMap(_))));
+    assert_eq!(ctx.config_path.as_deref(), Some("/test"));
+}
+
+#[test]
+fn context_status_all_configs_has_no_config_path() {
+    // `Status { config_path: None }` is a rights-free request — no authorizer context.
+    let req = Request::Status { config_path: None };
+    assert!(build_authorizer_context(&req, 1000, 1000, None, vec![1000], false).is_none());
+}
+
+#[test]
+fn request_table_has_config_path() {
+    let lua = create_acl_lua_vm().unwrap();
+    let ctx = make_context("start");
+    let tbl = build_request_table(&lua, &ctx).unwrap();
+    let path: String = tbl.get("config_path").unwrap();
+    assert_eq!(path, "/etc/kepler/app.kepler");
+}
+
+#[test]
+fn authorizer_can_read_config_path() {
+    let lua = create_acl_lua_vm().unwrap();
+    let ctx = make_context("start");
+    let key = compile_authorizer(
+        &lua,
+        "return request.config_path == '/etc/kepler/app.kepler'",
+    )
+    .unwrap();
+    let handle = RegistryKeyHandle(Arc::new(key));
+    let result = evaluate_authorizers(&lua, &[handle], &ctx);
+    assert!(result.is_ok());
 }
 
 #[test]

--- a/kepler-daemon/src/persistence.rs
+++ b/kepler-daemon/src/persistence.rs
@@ -155,8 +155,32 @@ impl ConfigPersistence {
                 Ok(Some(state))
             }
             Err(e) => {
-                warn!("Failed to parse state.json, ignoring: {}", e);
+                // The state file is corrupted and cannot be parsed. Quarantine it
+                // by renaming it aside so it can be inspected later, then return
+                // None so a fresh state.json is generated on the next save.
+                warn!("Failed to parse state.json: {}", e);
+                self.quarantine_corrupted_state(&path);
                 Ok(None)
+            }
+        }
+    }
+
+    /// Rename a corrupted state file aside as `state.json.corrupted.<timestamp>`.
+    ///
+    /// Best-effort: failures are logged but never propagated, since the caller
+    /// always falls back to a fresh state regardless.
+    fn quarantine_corrupted_state(&self, path: &Path) {
+        let timestamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
+        let file_name = path.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_else(|| "state.json".to_string());
+        let corrupted_name = format!("{}.corrupted.{}", file_name, timestamp);
+        let corrupted_path = path.with_file_name(&corrupted_name);
+
+        match std::fs::rename(path, &corrupted_path) {
+            Ok(()) => {
+                warn!("Quarantined corrupted state file to {:?}; a fresh state will be generated", corrupted_path);
+            }
+            Err(e) => {
+                warn!("Failed to quarantine corrupted state file {:?}: {}", path, e);
             }
         }
     }

--- a/kepler-daemon/src/persistence/tests.rs
+++ b/kepler-daemon/src/persistence/tests.rs
@@ -75,6 +75,48 @@ fn test_clear_snapshot() {
 }
 
 #[test]
+fn test_load_state_quarantines_corrupted_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let persistence = ConfigPersistence::new(temp_dir.path().to_path_buf());
+
+    // Write invalid JSON to state.json
+    std::fs::write(persistence.state_path(), "not valid json {{{").unwrap();
+
+    // Loading should succeed with None (fresh state) and not error out
+    let result = persistence.load_state().unwrap();
+    assert!(result.is_none(), "Corrupted state should load as None");
+
+    // The original state.json must have been moved aside
+    assert!(
+        !persistence.state_path().exists(),
+        "Corrupted state.json should have been renamed away"
+    );
+
+    // A quarantined copy should exist with the corrupted contents preserved
+    let quarantined: Vec<_> = std::fs::read_dir(temp_dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with("state.json.corrupted."))
+        .collect();
+    assert_eq!(
+        quarantined.len(),
+        1,
+        "Expected exactly one quarantined file, found: {:?}",
+        quarantined
+    );
+    let preserved = std::fs::read_to_string(temp_dir.path().join(&quarantined[0])).unwrap();
+    assert_eq!(preserved, "not valid json {{{");
+}
+
+#[test]
+fn test_load_state_none_when_missing() {
+    let temp_dir = TempDir::new().unwrap();
+    let persistence = ConfigPersistence::new(temp_dir.path().to_path_buf());
+    assert!(persistence.load_state().unwrap().is_none());
+}
+
+#[test]
 fn test_permission_ceiling_round_trip() {
     let yaml = r#"
 config:

--- a/kepler-e2e/config/authorization_test/test_acl_config_path.kepler.yaml
+++ b/kepler-e2e/config/authorization_test/test_acl_config_path.kepler.yaml
@@ -1,0 +1,22 @@
+kepler:
+  acl:
+    users:
+      testuser2:
+        allow: [start, stop, status, logs, subscribe, quiescence]
+        authorize: |
+          -- The daemon must expose the targeted config file path (`-f <path>`)
+          -- to authorizers as request.config_path. If it is missing or points
+          -- somewhere unexpected, fail closed.
+          if request.config_path == nil then
+            error("config_path missing from authorizer request")
+          end
+          if not string.match(request.config_path, "test_acl_config_path%.kepler%.yaml$") then
+            error("unexpected config_path: " .. tostring(request.config_path))
+          end
+          -- config_path is correctly populated: allow read actions, deny stop.
+          if request.action == 'stop' then return false end
+          return true
+
+services:
+  cfgpath-svc:
+    command: ["sh", "-c", "echo CFGPATH_SVC_RUNNING; sleep 300"]

--- a/kepler-e2e/tests/authorization_test.rs
+++ b/kepler-e2e/tests/authorization_test.rs
@@ -1037,6 +1037,51 @@ async fn test_lua_authorizer_error_denies_and_logs() -> E2eResult<()> {
     Ok(())
 }
 
+/// Lua authorizer can read the targeted config file path via `request.config_path`.
+/// The authorizer fails closed unless `request.config_path` points at this config,
+/// so a successful `ps` proves the path was delivered; `stop` is denied by the
+/// action branch that only runs once config_path is validated.
+#[tokio::test]
+async fn test_lua_authorizer_reads_config_path() -> E2eResult<()> {
+    let mut harness = E2eHarness::new().await?;
+    let config_path = harness.load_config(TEST_MODULE, "test_acl_config_path")?;
+
+    harness.start_daemon().await?;
+
+    // testuser1 (owner) starts the service — owner bypasses authorizers.
+    let output = harness.run_cli_as_user("testuser1", &["-f", config_path.to_str().unwrap(), "start", "-d"]).await?;
+    output.assert_success();
+    harness.wait_for_service_status(&config_path, "cfgpath-svc", "running", Duration::from_secs(10)).await?;
+
+    // testuser2 views status: allowed only because request.config_path was present
+    // AND matched the expected suffix (otherwise the authorizer error()s → deny).
+    let output = harness.run_cli_as_user("testuser2", &["-f", config_path.to_str().unwrap(), "ps"]).await?;
+    output.assert_success();
+    assert!(
+        output.stdout_contains("cfgpath-svc"),
+        "testuser2 should see service when config_path is delivered. stdout: {}", output.stdout
+    );
+
+    // testuser2 stop: denied by the action branch that runs after config_path is
+    // validated — proving the authorizer evaluated with config_path populated.
+    let output = harness.run_cli_as_user("testuser2", &["-f", config_path.to_str().unwrap(), "stop"]).await?;
+    assert!(!output.success(), "stop should be denied by the config_path-aware authorizer");
+    assert!(
+        output.stderr_contains("permission denied") || output.stderr_contains("denied"),
+        "Should mention denial. stderr: {}", output.stderr
+    );
+
+    // The authorizer must NOT have hit its fail-closed error() branches.
+    let daemon_logs = harness.daemon_logs();
+    assert!(
+        !daemon_logs.contains("config_path missing") && !daemon_logs.contains("unexpected config_path"),
+        "Authorizer should have received a valid config_path. daemon_logs: {}", daemon_logs
+    );
+
+    harness.stop_daemon().await?;
+    Ok(())
+}
+
 // =========================================================================
 // CLI degraded mode: partial permissions
 // =========================================================================


### PR DESCRIPTION
## What does this PR do ?

Exposes the targeted config file path to Lua authorizers as `request.config_path`. When a request carries a `-f <path>` argument, the daemon now resolves and passes that canonicalized path into the authorizer context, allowing authorizers to branch on which config file is being targeted. For example, an authorizer can deny `stop` actions on a specific critical config, or fail closed if the request targets an unexpected location.

The field is `nil` only for the rare requests that carry no config path (e.g. `Ping`, `ListConfigs`, `Shutdown`).

## Other changes ?

Corrupted `state.json` files are now quarantined rather than silently discarded. When `state.json` fails to parse, it is renamed to `state.json.corrupted.<timestamp>` so the bad file is preserved for inspection, and a fresh state is generated on the next save.

## How to Test ?

- Unit tests in `acl_runtime/tests.rs` verify that `request.config_path` is populated in the request table and that authorizers can read and match against it.
- Integration tests in `acl/tests.rs` cover allow/deny decisions driven by exact path matching and suffix matching via `string.match`.
- A new e2e test (`test_lua_authorizer_reads_config_path`) starts a service as `testuser1`, then verifies that `testuser2`'s `ps` succeeds (proving `config_path` was delivered and matched) while `stop` is denied by the action branch that only runs after `config_path` is validated.
- Persistence tests confirm that a corrupted `state.json` is renamed aside with the original contents preserved, and that a missing `state.json` returns `None` cleanly.