### PR TITLE
Make log streaming more resilient on failure and handle non-UTF-8 bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,6 +1184,7 @@ dependencies = [
  "kepler-unix",
  "nix",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
  "tokio",

--- a/kepler-cli/src/main.rs
+++ b/kepler-cli/src/main.rs
@@ -1380,6 +1380,20 @@ fn print_multi_config_table(configs: &[ConfigStatus]) {
 
     let table = Table::new(rows).with(Style::blank()).to_string();
     println!("{table}");
+
+    // Surface log-persistence degradation: the writer is failing to store logs
+    // even after reopening its connection, so logs are being dropped.
+    let degraded: Vec<String> = configs
+        .iter()
+        .filter(|c| c.log_degraded)
+        .map(|c| abbreviate_path(&c.config_path))
+        .collect();
+    if !degraded.is_empty() {
+        eprintln!(
+            "\n⚠  Log persistence DEGRADED (logs being dropped) for: {}",
+            degraded.join(", ")
+        );
+    }
 }
 
 

--- a/kepler-daemon/src/config_registry.rs
+++ b/kepler-daemon/src/config_registry.rs
@@ -151,10 +151,15 @@ impl ConfigRegistry {
 
         futures::future::join_all(handles.iter().map(|h| async {
             let services = h.get_service_status(None).await.unwrap_or_default();
+            let log_degraded = match h.get_log_store().await {
+                Some(store) => store.is_degraded(),
+                None => false,
+            };
             ConfigStatus {
                 config_path: h.config_path().to_string_lossy().to_string(),
                 config_hash: h.config_hash().to_string(),
                 services,
+                log_degraded,
             }
         }))
         .await

--- a/kepler-daemon/src/logs/store.rs
+++ b/kepler-daemon/src/logs/store.rs
@@ -38,6 +38,25 @@ pub(crate) struct InsertEntry {
     pub attributes: Option<String>,
 }
 
+/// Flags shared between the actor and its handles.
+///
+/// `Arc`-backed so a clone shares the same atomics. Cheap to clone.
+#[derive(Clone, Default)]
+struct SharedFlags {
+    /// Set when the writer cannot persist a batch even after reopening the
+    /// connection. Lets `kepler status`/callers observe "log persistence
+    /// degraded" instead of logs silently vanishing.
+    degraded: Arc<AtomicBool>,
+    /// Test-only fault-injection seam: when set, the next flush write fails as
+    /// if the open file descriptor were a stale NFS handle (ESTALE), and keeps
+    /// failing until the connection is reopened. This models the one error
+    /// class that is *persistent* on an open fd yet cleared by reopening —
+    /// the real-world cause of permanent log dropout that cannot be reproduced
+    /// hermetically without a real NFS mount.
+    #[cfg(test)]
+    inject_fail_until_reopen: Arc<AtomicBool>,
+}
+
 /// Cloneable handle to the LogStore actor.
 #[derive(Clone)]
 pub struct LogStoreHandle {
@@ -50,6 +69,8 @@ pub struct LogStoreHandle {
     discard_flag: Arc<AtomicBool>,
     /// SQLite interrupt handle — abort any running query from another thread.
     interrupt_handle: Option<Arc<std::sync::Mutex<rusqlite::InterruptHandle>>>,
+    /// Health/degraded flag and test fault-injection, shared with the actor.
+    flags: SharedFlags,
 }
 
 impl std::fmt::Debug for LogStoreHandle {
@@ -76,17 +97,22 @@ impl LogStoreHandle {
         let (tx, rx) = std::sync::mpsc::channel();
         let pending_count = Arc::new(AtomicU64::new(0));
         let discard_flag = Arc::new(AtomicBool::new(false));
+        let flags = SharedFlags::default();
 
         // Wait for the actor thread to finish creating the database schema
         // before returning the handle. This prevents readers from seeing an
         // empty database (no `logs` table) if they query before schema creation.
-        // The actor sends back the SQLite interrupt handle so we can abort
-        // long-running queries from another thread during shutdown_discard().
-        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel::<rusqlite::InterruptHandle>(1);
+        // The actor sends back a shared, mutable interrupt handle so we can
+        // abort long-running queries from another thread during
+        // shutdown_discard() — shared so it can be refreshed if the actor
+        // reopens its connection after a write error.
+        let (ready_tx, ready_rx) =
+            std::sync::mpsc::sync_channel::<Arc<std::sync::Mutex<rusqlite::InterruptHandle>>>(1);
 
         let actor_db_path = db_path.clone();
         let actor_pending = Arc::clone(&pending_count);
         let actor_discard = Arc::clone(&discard_flag);
+        let actor_flags = flags.clone();
         std::thread::Builder::new()
             .name("log-store".into())
             .spawn(move || {
@@ -101,6 +127,7 @@ impl LogStoreHandle {
                     actor_discard,
                     retention_period,
                     cleanup_interval,
+                    actor_flags,
                 ) {
                     Ok(a) => a,
                     Err(e) => {
@@ -109,7 +136,10 @@ impl LogStoreHandle {
                         return;
                     }
                 };
-                let _ = ready_tx.send(actor.conn.get_interrupt_handle());
+                let shared_interrupt =
+                    Arc::new(std::sync::Mutex::new(actor.conn.get_interrupt_handle()));
+                actor.interrupt_handle = Some(Arc::clone(&shared_interrupt));
+                let _ = ready_tx.send(shared_interrupt);
                 actor.run();
                 drop(actor);
             })
@@ -117,10 +147,9 @@ impl LogStoreHandle {
 
         // Block until schema is created (or thread panics/errors).
         // If the actor failed to start, ready_tx is dropped and we get None.
-        let interrupt_handle = ready_rx.recv().ok()
-            .map(|h| Arc::new(std::sync::Mutex::new(h)));
+        let interrupt_handle = ready_rx.recv().ok();
 
-        Self { tx, db_path, storage_mode, pending_count, discard_flag, interrupt_handle }
+        Self { tx, db_path, storage_mode, pending_count, discard_flag, interrupt_handle, flags }
     }
 
     /// Send a write command (non-blocking, drops entry on disconnect).
@@ -135,6 +164,20 @@ impl LogStoreHandle {
     /// flushed to SQLite (still in the channel or batch buffer).
     pub fn has_pending(&self) -> bool {
         self.pending_count.load(Ordering::Relaxed) > 0
+    }
+
+    /// Returns `true` if the writer is currently unable to persist logs — every
+    /// flush is failing even after reopening the connection. Surfaces the
+    /// previously-silent "logs vanish on a persistent NFS/disk error" failure.
+    pub fn is_degraded(&self) -> bool {
+        self.flags.degraded.load(Ordering::Relaxed)
+    }
+
+    /// Test-only fault-injection seam: make every flush write fail (as if the
+    /// open fd were a stale NFS handle) until the actor reopens its connection.
+    #[cfg(test)]
+    pub fn test_inject_fail_until_reopen(&self) {
+        self.flags.inject_fail_until_reopen.store(true, Ordering::Relaxed);
     }
 
     /// Path to the SQLite database file.
@@ -213,6 +256,12 @@ impl LogStoreHandle {
 
 pub const DEFAULT_BATCH_SIZE: usize = 4096;
 
+/// How many times to reopen the connection and retry a failed flush before
+/// giving up and dropping the batch. A persistent NFS stale-fd error is only
+/// cleared by reopening, so one reopen+retry usually recovers; a few attempts
+/// absorbs transient errors without spinning forever on a truly dead disk.
+const MAX_FLUSH_REOPEN_ATTEMPTS: u32 = 3;
+
 const LOG_DELETE_SQL: &str =
     "DELETE FROM logs WHERE id IN (SELECT id FROM logs WHERE timestamp < ?1 ORDER BY timestamp LIMIT ?2)";
 
@@ -229,6 +278,15 @@ struct LogStoreActor {
     cleanup_interval: Duration,
     last_cleanup: Instant,
     cleanup_has_more: bool,
+    /// DB path + storage mode, retained so the connection can be reopened after
+    /// a persistent write error (e.g. NFS stale file handle).
+    db_path: PathBuf,
+    storage_mode: StorageMode,
+    /// Shared interrupt handle, refreshed on reopen so shutdown_discard() keeps
+    /// pointing at the live connection.
+    interrupt_handle: Option<Arc<std::sync::Mutex<rusqlite::InterruptHandle>>>,
+    /// Degraded flag + test fault-injection, shared with the handle.
+    flags: SharedFlags,
 }
 
 impl LogStoreActor {
@@ -243,6 +301,7 @@ impl LogStoreActor {
         discard_flag: Arc<AtomicBool>,
         retention_period: Option<Duration>,
         cleanup_interval: Duration,
+        flags: SharedFlags,
     ) -> Result<Self, rusqlite::Error> {
         // Ensure parent directory exists
         if let Some(parent) = db_path.parent() {
@@ -283,6 +342,10 @@ impl LogStoreActor {
             cleanup_interval,
             last_cleanup: Instant::now(),
             cleanup_has_more: false,
+            db_path: db_path.to_path_buf(),
+            storage_mode,
+            interrupt_handle: None,
+            flags,
         })
     }
 
@@ -565,37 +628,94 @@ impl LogStoreActor {
 
     fn flush_batch(&mut self) {
         if self.batch.is_empty() {
+            // Idle re-validation: if a previous flush gave up and marked us
+            // degraded, but persistence has since recovered, clear the flag so
+            // `is_degraded()` doesn't report a false "DEGRADED" forever when the
+            // producing service has gone quiet (no further batches to flush).
+            // A successful reopen means the FS/fd is healthy again — and reopen
+            // is the only thing that clears a stale NFS fd. Skip during discard.
+            if self.flags.degraded.load(Ordering::Relaxed)
+                && !self.discard_flag.load(Ordering::Relaxed)
+                && self.reopen_connection().is_ok()
+            {
+                self.flags.degraded.store(false, Ordering::Relaxed);
+                tracing::info!("log store: persistence healthy again (revalidated while idle)");
+            }
             return;
         }
 
         let count = self.batch.len() as u64;
 
-        let result = (|| -> Result<(), rusqlite::Error> {
-            let tx = self.conn.transaction()?;
-            {
-                let mut stmt = tx.prepare_cached(
-                    "INSERT INTO logs (timestamp, service, hook, level, line, attributes) \
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                )?;
-
-                for entry in self.batch.drain(..) {
-                    stmt.execute(params![
-                        entry.timestamp,
-                        entry.service,
-                        entry.hook,
-                        entry.level,
-                        entry.line,
-                        entry.attributes,
-                    ])?;
+        // Try to persist; on a write error, reopen the connection and retry the
+        // SAME batch. A persistent NFS stale file handle (ESTALE -> SQLITE_IOERR
+        // under synchronous=FULL) keeps failing on the open fd forever but is
+        // cleared by reopening — so the previous "warn + drop, never reopen"
+        // behavior meant a single NFS hiccup silently froze all logging until
+        // daemon restart. The batch is NOT drained until a commit succeeds, so
+        // a retry re-inserts the same entries (no data loss on recovery).
+        //
+        // Trade-off: if a commit returns an error *after* the rows were already
+        // made durable (an ambiguous IO error during COMMIT finalization), the
+        // retry re-inserts them and they appear twice (the logs table has no
+        // unique key). We deliberately favor no-loss over no-duplicates for
+        // logs; duplicates are rare and far less harmful than dropped lines.
+        let mut last_err: Option<rusqlite::Error> = None;
+        let mut stored = false;
+        let mut discarding = false;
+        for attempt in 0..=MAX_FLUSH_REOPEN_ATTEMPTS {
+            // Honor shutdown_discard(): it sets discard_flag and interrupts the
+            // in-flight INSERT (which surfaces here as an error). Retrying or
+            // reopening would defeat the interrupt, re-persist the batch the
+            // caller asked to drop, and — since reopen uses OPEN_CREATE —
+            // recreate the DB in a state dir that is being deleted.
+            if self.discard_flag.load(Ordering::Relaxed) {
+                discarding = true;
+                break;
+            }
+            match self.try_write_batch() {
+                Ok(()) => {
+                    stored = true;
+                    break;
+                }
+                Err(e) => {
+                    last_err = Some(e);
+                    if attempt < MAX_FLUSH_REOPEN_ATTEMPTS {
+                        tracing::warn!(
+                            "log store flush failed (attempt {}), reopening connection",
+                            attempt + 1
+                        );
+                        if let Err(reopen_err) = self.reopen_connection() {
+                            tracing::warn!("log store: reopen after flush error failed: {}", reopen_err);
+                        }
+                    }
                 }
             }
-            tx.commit()?;
-            Ok(())
-        })();
+        }
 
-        if let Err(e) = result {
-            tracing::warn!("Failed to flush log batch: {}", e);
+        if stored {
             self.batch.clear();
+            if self.flags.degraded.swap(false, Ordering::Relaxed) {
+                tracing::info!("log store: flush recovered, persistence healthy again");
+            }
+        } else if discarding {
+            // Discard in progress: drop the batch quietly. This is not a
+            // persistence failure, so do not raise the degraded flag — the whole
+            // state directory is about to be deleted.
+            self.batch.clear();
+        } else {
+            // Could not persist even after reopening. Drop the batch to avoid
+            // unbounded memory growth, but raise the degraded flag so the
+            // failure is observable instead of silent.
+            if let Some(e) = last_err {
+                tracing::error!(
+                    "log store: dropping {} entries after {} failed flush attempts: {}",
+                    count,
+                    MAX_FLUSH_REOPEN_ATTEMPTS + 1,
+                    e
+                );
+            }
+            self.batch.clear();
+            self.flags.degraded.store(true, Ordering::Relaxed);
         }
 
         self.pending_count.fetch_sub(count, Ordering::Relaxed);
@@ -604,6 +724,77 @@ impl LogStoreActor {
             log_notify.notify_waiters();
         }
     }
+
+    /// Insert the current batch in a single transaction WITHOUT draining it, so
+    /// the batch survives for a retry if the commit fails.
+    fn try_write_batch(&mut self) -> Result<(), rusqlite::Error> {
+        // Test-only seam: simulate a stale-fd write failure until reopen.
+        #[cfg(test)]
+        if self.flags.inject_fail_until_reopen.load(Ordering::Relaxed) {
+            return Err(injected_stale_fd_error());
+        }
+
+        let tx = self.conn.transaction()?;
+        {
+            let mut stmt = tx.prepare_cached(
+                "INSERT INTO logs (timestamp, service, hook, level, line, attributes) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            )?;
+
+            for entry in &self.batch {
+                stmt.execute(params![
+                    entry.timestamp,
+                    entry.service,
+                    entry.hook,
+                    entry.level,
+                    entry.line,
+                    entry.attributes,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Drop the current write connection and open a fresh one. This is the only
+    /// thing that clears an NFS stale file handle (the fd is poisoned until the
+    /// file is reopened). The shared interrupt handle is refreshed so
+    /// shutdown_discard() keeps targeting the live connection.
+    fn reopen_connection(&mut self) -> Result<(), rusqlite::Error> {
+        let conn = Connection::open_with_flags(
+            &self.db_path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE
+                | OpenFlags::SQLITE_OPEN_CREATE
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        crate::db_cleanup::setup_writer_connection(&conn, self.storage_mode)?;
+        create_schema(&conn)?;
+
+        if let Some(ref shared) = self.interrupt_handle {
+            if let Ok(mut guard) = shared.lock() {
+                *guard = conn.get_interrupt_handle();
+            }
+        }
+
+        self.conn = conn;
+
+        // A freshly reopened connection has a valid fd, so the simulated
+        // stale-fd condition is cleared — mirroring real ESTALE-then-reopen.
+        #[cfg(test)]
+        self.flags.inject_fail_until_reopen.store(false, Ordering::Relaxed);
+
+        Ok(())
+    }
+}
+
+/// Build a fake `SQLITE_IOERR` failure used by the test fault-injection seam to
+/// model an NFS stale file handle.
+#[cfg(test)]
+fn injected_stale_fd_error() -> rusqlite::Error {
+    rusqlite::Error::SqliteFailure(
+        rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_IOERR),
+        Some("injected stale-fd failure (test)".to_string()),
+    )
 }
 
 // ============================================================================
@@ -650,6 +841,195 @@ pub fn open_readonly(db_path: &Path) -> Result<Connection, rusqlite::Error> {
 #[cfg(test)]
 mod tests {
     use rusqlite::{Connection, params};
+
+    use std::time::Duration;
+
+    use super::{DEFAULT_BATCH_SIZE, LogStoreHandle};
+    use crate::config::StorageMode;
+    use crate::logs::{LogWriter, SqliteLogReader};
+
+    /// Read all stored log lines for the test service, newest-first order.
+    fn stored_lines(db_path: &std::path::Path) -> Vec<String> {
+        let reader = SqliteLogReader::new(db_path.to_path_buf(), StorageMode::Nfs);
+        reader
+            .tail(1000, &[], false, None, None, None)
+            .into_iter()
+            .map(|e| e.line)
+            .collect()
+    }
+
+    /// A persistent write error (modeled as an NFS stale file handle that fails
+    /// every write until the connection is reopened) must NOT permanently stop
+    /// log persistence: the store should reopen its connection, retry the
+    /// in-flight batch, and resume storing logs — and report `is_degraded()`
+    /// only while actually broken.
+    ///
+    /// Before the fix, the actor never reopened the connection, so the injected
+    /// fault never cleared: every subsequent flush failed and the DB stopped
+    /// gaining rows forever. With `MAX_FLUSH_REOPEN_ATTEMPTS = 0` this test
+    /// reproduces that red behavior; with the default (3) it goes green.
+    #[test]
+    fn flush_recovers_by_reopening_after_persistent_write_error() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("logs").join("logs.db");
+
+        let store = LogStoreHandle::spawn(
+            db_path.clone(),
+            Duration::from_millis(5),
+            DEFAULT_BATCH_SIZE,
+            StorageMode::Nfs,
+            None,
+            None,
+            Duration::from_secs(3600),
+        );
+
+        // Baseline: a normal write is stored, store is healthy.
+        LogWriter::new(&store, "svc", "info").write("A_before_fault");
+        store.wait_flush_sync();
+        assert!(
+            stored_lines(&db_path).iter().any(|l| l == "A_before_fault"),
+            "baseline write should be stored"
+        );
+        assert!(!store.is_degraded(), "store should start healthy");
+
+        // Simulate a persistent stale-fd error: every write fails until reopen.
+        store.test_inject_fail_until_reopen();
+
+        // This flush fails, then (with the fix) reopens + retries, clearing the
+        // injected fault and persisting the in-flight batch.
+        LogWriter::new(&store, "svc", "info").write("B_during_fault");
+        store.wait_flush_sync();
+
+        // A later write must also land — proving the store recovered rather than
+        // silently dropping every subsequent batch forever.
+        LogWriter::new(&store, "svc", "info").write("C_after_fault");
+        store.wait_flush_sync();
+
+        let lines = stored_lines(&db_path);
+        assert!(
+            lines.iter().any(|l| l == "C_after_fault"),
+            "store must reopen and resume persisting logs after a stale-fd error; got {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l == "B_during_fault"),
+            "the batch in flight during the fault must be retried, not dropped; got {lines:?}"
+        );
+        assert!(
+            !store.is_degraded(),
+            "store should report healthy again after recovery"
+        );
+
+        store.shutdown();
+    }
+
+    /// When the discard flag is set (stop --clean / prune), a failing flush must
+    /// NOT reopen/retry: doing so would defeat shutdown_discard()'s interrupt,
+    /// re-persist the discarded batch, and recreate the DB in a state dir being
+    /// deleted. The batch is dropped quietly and `degraded` is not raised.
+    #[test]
+    fn flush_honors_discard_without_reopening() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("logs.db");
+        let (_tx, rx) = std::sync::mpsc::channel();
+        let pending = Arc::new(AtomicU64::new(0));
+        let discard = Arc::new(AtomicBool::new(false));
+        let flags = super::SharedFlags::default();
+
+        let mut actor = super::LogStoreActor::new(
+            &db_path,
+            rx,
+            Duration::from_millis(5),
+            DEFAULT_BATCH_SIZE,
+            StorageMode::Local,
+            None,
+            Arc::clone(&pending),
+            Arc::clone(&discard),
+            None,
+            Duration::from_secs(3600),
+            flags.clone(),
+        )
+        .unwrap();
+
+        actor.batch.push(super::InsertEntry {
+            timestamp: 1,
+            service: "svc".to_string(),
+            hook: None,
+            level: "info",
+            line: "should_be_discarded".to_string(),
+            attributes: None,
+        });
+        pending.fetch_add(1, Ordering::Relaxed);
+
+        // Simulate shutdown_discard(): discard flag set, and writes failing as an
+        // interrupted INSERT would. `inject_fail_until_reopen` staying true after
+        // the flush proves reopen() was never called.
+        discard.store(true, Ordering::Relaxed);
+        flags.inject_fail_until_reopen.store(true, Ordering::Relaxed);
+
+        actor.flush_batch();
+
+        assert!(actor.batch.is_empty(), "batch should be dropped during discard");
+        assert!(
+            !flags.degraded.load(Ordering::Relaxed),
+            "discard is not a persistence degradation"
+        );
+        assert!(
+            flags.inject_fail_until_reopen.load(Ordering::Relaxed),
+            "reopen must NOT run during discard (a reopen would clear this flag)"
+        );
+
+        let reader = SqliteLogReader::new(db_path, StorageMode::Local);
+        let lines = reader.tail(100, &[], false, None, None, None);
+        assert!(
+            lines.is_empty(),
+            "no rows should be persisted during discard; got {:?}",
+            lines.iter().map(|e| &e.line).collect::<Vec<_>>()
+        );
+    }
+
+    /// Once `degraded` is set, an idle flush (empty batch) must re-validate and
+    /// clear it when persistence has recovered, so `is_degraded()` does not
+    /// report a false "DEGRADED" forever after the producing service goes quiet.
+    #[test]
+    fn idle_flush_revalidates_and_clears_degraded() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("logs.db");
+        let (_tx, rx) = std::sync::mpsc::channel();
+        let flags = super::SharedFlags::default();
+
+        let mut actor = super::LogStoreActor::new(
+            &db_path,
+            rx,
+            Duration::from_millis(5),
+            DEFAULT_BATCH_SIZE,
+            StorageMode::Local,
+            None,
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicBool::new(false)),
+            None,
+            Duration::from_secs(3600),
+            flags.clone(),
+        )
+        .unwrap();
+
+        // A prior flush gave up and marked us degraded; the batch is now empty
+        // (producer quiet) and the FS is healthy.
+        flags.degraded.store(true, Ordering::Relaxed);
+        assert!(actor.batch.is_empty());
+
+        actor.flush_batch(); // empty-batch path -> idle re-validation -> reopen ok
+
+        assert!(
+            !flags.degraded.load(Ordering::Relaxed),
+            "idle flush should re-validate and clear a stale degraded flag once healthy"
+        );
+    }
 
     const BATCHED_DELETE_SQL: &str =
         "DELETE FROM logs WHERE id IN (SELECT id FROM logs WHERE timestamp < ?1 ORDER BY timestamp LIMIT ?2)";

--- a/kepler-daemon/src/main.rs
+++ b/kepler-daemon/src/main.rs
@@ -1237,10 +1237,15 @@ async fn handle_request(
                     .collect();
                 let configs = futures::future::join_all(visible_handles.iter().map(|h| async {
                     let services = h.get_service_status(None).await.unwrap_or_default();
+                    let log_degraded = match h.get_log_store().await {
+                        Some(store) => store.is_degraded(),
+                        None => false,
+                    };
                     kepler_protocol::protocol::ConfigStatus {
                         config_path: h.config_path().to_string_lossy().to_string(),
                         config_hash: h.config_hash().to_string(),
                         services,
+                        log_degraded,
                     }
                 })).await;
                 Response::ok_with_data(ResponseData::MultiConfigStatus(configs))
@@ -1536,12 +1541,25 @@ async fn handle_request(
                 .and_then(|k| serde_json::to_value(k).ok())
                 .unwrap_or(serde_json::Value::Null);
 
+            // Log-store health (operational; not gated). `degraded` is true when
+            // the writer cannot persist logs even after reopening its connection
+            // (e.g. a persistent NFS/disk error) — previously a silent failure.
+            let logs_degraded = if let Some(handle) = registry.get(&config_path) {
+                match handle.get_log_store().await {
+                    Some(store) => store.is_degraded(),
+                    None => false,
+                }
+            } else {
+                false
+            };
+
             // Base info — always included
             let mut result = serde_json::json!({
                 "config_path": config_path.to_string_lossy(),
                 "config_hash": config_hash,
                 "state_dir": state_dir_str,
                 "kepler": kepler_value,
+                "logs": { "degraded": logs_degraded },
             });
             let obj = result.as_object_mut().unwrap();
 

--- a/kepler-daemon/src/monitor/writer.rs
+++ b/kepler-daemon/src/monitor/writer.rs
@@ -196,6 +196,8 @@ impl MonitorHandle {
 
 const DEFAULT_CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
 const FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+/// Connection reopen+retry attempts on a failed flush before dropping the batch.
+const MAX_FLUSH_REOPEN_ATTEMPTS: u32 = 3;
 
 const METRICS_DELETE_SQL: &str =
     "DELETE FROM metrics WHERE rowid IN (SELECT rowid FROM metrics WHERE timestamp < ?1 ORDER BY timestamp LIMIT ?2)";
@@ -216,6 +218,10 @@ struct MonitorWriterActor {
     cleanup_interval: Duration,
     last_cleanup: Instant,
     cleanup_has_more: bool,
+    /// DB path + storage mode, retained so the connection can be reopened after
+    /// a persistent write error (e.g. NFS stale file handle).
+    db_path: std::path::PathBuf,
+    storage_mode: StorageMode,
 }
 
 impl MonitorWriterActor {
@@ -247,6 +253,8 @@ impl MonitorWriterActor {
             cleanup_interval,
             last_cleanup: Instant::now(),
             cleanup_has_more: false,
+            db_path,
+            storage_mode,
         })
     }
 
@@ -419,37 +427,100 @@ impl MonitorWriterActor {
             return;
         }
 
-        let result = (|| -> Result<(), rusqlite::Error> {
-            let tx = self.conn.transaction()?;
-            {
-                let mut stmt = tx.prepare_cached(
-                    "INSERT INTO metrics (timestamp, service, cpu_percent, memory_rss, memory_vss, pids)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                )?;
-
-                for (timestamp, metrics) in self.batch.drain(..) {
-                    for m in metrics {
-                        let pids_json =
-                            serde_json::to_string(&m.pids).unwrap_or_else(|_| "[]".to_string());
-                        stmt.execute(params![
-                            timestamp,
-                            m.service,
-                            m.cpu_percent,
-                            m.memory_rss,
-                            m.memory_vss,
-                            pids_json,
-                        ])?;
+        // Reopen-and-retry on write error: an NFS stale file handle poisons the
+        // open fd until reopened, so the previous "warn + drop, never reopen"
+        // path silently froze metric persistence after a single NFS hiccup. The
+        // batch is not drained until a commit succeeds, so a retry re-inserts
+        // the same samples. (As in the log store, an ambiguous durable-then-Err
+        // commit can duplicate a sample — we favor no-loss over no-duplicates.)
+        let mut last_err: Option<rusqlite::Error> = None;
+        let mut stored = false;
+        let mut discarding = false;
+        for attempt in 0..=MAX_FLUSH_REOPEN_ATTEMPTS {
+            // Honor discard(): on clean shutdown it sets the discard flag and
+            // interrupts the in-flight write. Retrying/reopening would defeat the
+            // interrupt and recreate monitor.db (reopen uses OPEN_CREATE) in the
+            // state dir being deleted.
+            if self.discard_flag() {
+                discarding = true;
+                break;
+            }
+            match self.try_write_batch() {
+                Ok(()) => {
+                    stored = true;
+                    break;
+                }
+                Err(e) => {
+                    last_err = Some(e);
+                    if attempt < MAX_FLUSH_REOPEN_ATTEMPTS {
+                        tracing::warn!(
+                            "monitor flush failed (attempt {}), reopening connection",
+                            attempt + 1
+                        );
+                        if let Err(reopen_err) = self.reopen_connection() {
+                            tracing::warn!("monitor: reopen after flush error failed: {}", reopen_err);
+                        }
                     }
                 }
             }
-            tx.commit()?;
-            Ok(())
-        })();
-
-        if let Err(e) = result {
-            tracing::warn!("Failed to flush monitor batch: {}", e);
-            self.batch.clear();
         }
+
+        if !discarding && let Some(e) = last_err {
+            if stored {
+                tracing::info!("monitor: flush recovered after reopening connection");
+            } else {
+                tracing::error!("monitor: dropping batch after {} failed flush attempts: {}", MAX_FLUSH_REOPEN_ATTEMPTS + 1, e);
+            }
+        }
+        // Either persisted, discarded, or unrecoverable — drop the (now-stale) batch.
+        self.batch.clear();
+    }
+
+    /// Insert the current batch in one transaction WITHOUT draining it, so the
+    /// batch survives for a retry if the commit fails.
+    fn try_write_batch(&mut self) -> Result<(), rusqlite::Error> {
+        let tx = self.conn.transaction()?;
+        {
+            let mut stmt = tx.prepare_cached(
+                "INSERT INTO metrics (timestamp, service, cpu_percent, memory_rss, memory_vss, pids)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            )?;
+
+            for (timestamp, metrics) in &self.batch {
+                for m in metrics {
+                    let pids_json =
+                        serde_json::to_string(&m.pids).unwrap_or_else(|_| "[]".to_string());
+                    stmt.execute(params![
+                        timestamp,
+                        m.service,
+                        m.cpu_percent,
+                        m.memory_rss,
+                        m.memory_vss,
+                        pids_json,
+                    ])?;
+                }
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Drop the current write connection and open a fresh one — the only thing
+    /// that clears an NFS stale file handle. Refreshes the shared interrupt
+    /// handle so shutdown_discard() keeps targeting the live connection.
+    fn reopen_connection(&mut self) -> Result<(), rusqlite::Error> {
+        let conn = Connection::open_with_flags(
+            &self.db_path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE
+                | OpenFlags::SQLITE_OPEN_CREATE
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        db_cleanup::setup_writer_connection(&conn, self.storage_mode)?;
+        create_schema(&conn)?;
+
+        *self.shutdown_token.interrupt_handle.lock() = Some(conn.get_interrupt_handle());
+        self.conn = conn;
+        Ok(())
     }
 
     fn discard(&mut self) {
@@ -590,8 +661,8 @@ mod tests {
     #[test]
     fn flush_batch_inserts_metrics() {
         use super::{MonitorWriterActor, ServiceMetrics, MonitorShutdownToken};
+        use crate::config::StorageMode;
         use std::sync::Arc;
-        use std::sync::atomic::AtomicBool;
         use std::time::{Duration, Instant};
 
         let conn = Connection::open_in_memory().unwrap();
@@ -609,6 +680,8 @@ mod tests {
             cleanup_interval: Duration::from_secs(60),
             last_cleanup: Instant::now(),
             cleanup_has_more: false,
+            db_path: std::path::PathBuf::from(":memory:"),
+            storage_mode: StorageMode::Local,
         };
 
         // Push metrics into the batch
@@ -653,6 +726,7 @@ mod tests {
     #[test]
     fn no_retention_means_no_cleanup() {
         use super::{MonitorWriterActor, MonitorShutdownToken};
+        use crate::config::StorageMode;
         use std::sync::Arc;
         use std::time::{Duration, Instant};
 
@@ -671,6 +745,8 @@ mod tests {
             cleanup_interval: Duration::from_secs(60),
             last_cleanup: Instant::now() - Duration::from_secs(120), // well past interval
             cleanup_has_more: false,
+            db_path: std::path::PathBuf::from(":memory:"),
+            storage_mode: StorageMode::Local,
         };
 
         // With retention_period = None, should_cleanup must return false

--- a/kepler-daemon/src/process/spawn.rs
+++ b/kepler-daemon/src/process/spawn.rs
@@ -3,6 +3,7 @@
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::OnceLock;
+use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::task::JoinHandle;
@@ -11,6 +12,13 @@ use tracing::{debug, info, warn};
 use super::CommandSpec;
 use crate::errors::{DaemonError, Result};
 use crate::logs::{LogStoreHandle, LogWriter};
+
+/// Max consecutive read errors tolerated on a captured stream before giving up.
+/// A read error does not close the pipe fd, so we retry rather than permanently
+/// ending capture; the cap stops a persistent error from hot-spinning.
+const MAX_CAPTURE_READ_RETRIES: u32 = 5;
+/// Backoff between capture read retries (keeps a persistent error from spinning).
+const CAPTURE_READ_RETRY_BACKOFF: Duration = Duration::from_millis(50);
 
 /// Cached result of kepler-exec binary lookup.
 /// `Some(path)` = found, `None` = not found (will fall back to fork).
@@ -283,37 +291,68 @@ fn build_command(spec: &CommandSpec) -> Result<(Command, String)> {
     Ok((cmd, program.clone()))
 }
 
-/// Spawn a task that reads and discards all lines from a stream.
+/// Strip a single trailing `\n` (and a preceding `\r`, if present) from a line
+/// buffer read via `read_until(b'\n', ...)`, matching the newline trimming that
+/// `AsyncBufReadExt::lines()` performs.
+fn strip_trailing_newline(buf: &mut Vec<u8>) {
+    if buf.last() == Some(&b'\n') {
+        buf.pop();
+        if buf.last() == Some(&b'\r') {
+            buf.pop();
+        }
+    }
+}
+
+/// Spawn a task that reads and discards all output from a stream.
 /// Prevents the child process from blocking on a full pipe buffer.
+///
+/// Reads raw bytes (not UTF-8 lines) so that non-UTF-8 output cannot abort the
+/// drain early and leave the child blocked writing to a full pipe.
 fn spawn_drain_task(
     stream: Option<impl tokio::io::AsyncRead + Unpin + Send + 'static>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         if let Some(stream) = stream {
-            let reader = BufReader::new(stream);
-            let mut lines = reader.lines();
-            while let Ok(Some(_)) = lines.next_line().await {}
+            let mut reader = BufReader::new(stream);
+            let mut buf = Vec::new();
+            loop {
+                buf.clear();
+                match reader.read_until(b'\n', &mut buf).await {
+                    Ok(0) | Err(_) => break, // EOF or I/O error
+                    Ok(_) => {}              // discard
+                }
+            }
         }
     })
 }
 
 /// Spawn a task that collects all output from a stream into a String.
+///
+/// Reads raw bytes and lossily decodes each line, so non-UTF-8 output is
+/// preserved (as U+FFFD) instead of truncating the collected output.
 fn spawn_collect_task(
     stream: Option<impl tokio::io::AsyncRead + Unpin + Send + 'static>,
 ) -> JoinHandle<String> {
     tokio::spawn(async move {
-        let mut buf = String::new();
+        let mut out = String::new();
         if let Some(stream) = stream {
-            let reader = BufReader::new(stream);
-            let mut lines = reader.lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                if !buf.is_empty() {
-                    buf.push('\n');
+            let mut reader = BufReader::new(stream);
+            let mut buf = Vec::new();
+            loop {
+                buf.clear();
+                match reader.read_until(b'\n', &mut buf).await {
+                    Ok(0) | Err(_) => break, // EOF or I/O error
+                    Ok(_) => {
+                        strip_trailing_newline(&mut buf);
+                        if !out.is_empty() {
+                            out.push('\n');
+                        }
+                        out.push_str(&String::from_utf8_lossy(&buf));
+                    }
                 }
-                buf.push_str(&line);
             }
         }
-        buf
+        out
     })
 }
 
@@ -353,9 +392,53 @@ fn spawn_capture_task(
                 None
             };
 
-            let reader = BufReader::new(stream);
-            let mut lines = reader.lines();
-            while let Ok(Some(line)) = lines.next_line().await {
+            // Read raw bytes (not UTF-8 lines): a single invalid-UTF-8 byte must
+            // not return an Err that silently ends capture and freezes this
+            // service's logs. Invalid bytes are lossily decoded to U+FFFD; a
+            // genuine I/O error is logged before ending the loop.
+            let mut reader = BufReader::new(stream);
+            let mut buf = Vec::new();
+            // Consecutive read errors. A read error does NOT close the pipe fd,
+            // so retry (bounded, with backoff) instead of permanently ending
+            // capture — one transient hiccup (more likely under GVisor's syscall
+            // emulation) must not silence a service's logs until it restarts.
+            // Reset on any successful read.
+            let mut read_errors: u32 = 0;
+            loop {
+                // NOTE: `buf` is cleared only after a line is successfully
+                // extracted (below), NOT at the top of the loop. On a transient
+                // read error mid-line, read_until leaves the partial bytes it
+                // already read in `buf`; keeping them means the retry's
+                // read_until appends the rest and we emit the whole line intact
+                // instead of splitting/dropping it.
+                let line = match reader.read_until(b'\n', &mut buf).await {
+                    Ok(0) => break, // EOF
+                    Ok(_) => {
+                        read_errors = 0;
+                        strip_trailing_newline(&mut buf);
+                        let line = String::from_utf8_lossy(&buf).into_owned();
+                        buf.clear();
+                        line
+                    }
+                    Err(e) => {
+                        read_errors += 1;
+                        if read_errors > MAX_CAPTURE_READ_RETRIES {
+                            warn!(
+                                "[{}] ending log capture after {} consecutive read errors: {}",
+                                service_name, read_errors, e
+                            );
+                            break;
+                        }
+                        warn!(
+                            "[{}] log capture read error (retry {}/{}): {}",
+                            service_name, read_errors, MAX_CAPTURE_READ_RETRIES, e
+                        );
+                        tokio::time::sleep(CAPTURE_READ_RETRY_BACKOFF).await;
+                        // Do NOT clear `buf` — preserve the partial line for retry.
+                        continue;
+                    }
+                };
+
                 // Check for ::output:: marker
                 if let Some(ref mut cap) = captured
                     && let Some(kv) = line.strip_prefix("::output::") {
@@ -559,4 +642,155 @@ pub async fn spawn_detached(
         stdout_task,
         stderr_task,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tempfile::TempDir;
+    use tokio::io::{AsyncRead, ReadBuf};
+
+    use crate::config::StorageMode;
+    use crate::logs::{DEFAULT_BATCH_SIZE, SqliteLogReader};
+
+    /// An `AsyncRead` that replays a scripted sequence of results: each `Ok`
+    /// delivers a chunk of bytes, each `Err` surfaces a (transient) read error
+    /// exactly once, and the end of the script is EOF. Models a flaky pipe.
+    struct ScriptedReader {
+        steps: VecDeque<std::io::Result<&'static [u8]>>,
+    }
+
+    impl AsyncRead for ScriptedReader {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            match self.steps.pop_front() {
+                Some(Ok(bytes)) => {
+                    buf.put_slice(bytes);
+                    Poll::Ready(Ok(()))
+                }
+                Some(Err(e)) => Poll::Ready(Err(e)),
+                None => Poll::Ready(Ok(())), // EOF
+            }
+        }
+    }
+
+    /// A transient read error mid-stream must NOT permanently end capture: the
+    /// line emitted after the error must still be stored (the pipe fd stays
+    /// valid across a read error, so the loop retries instead of giving up).
+    #[tokio::test]
+    async fn capture_recovers_from_transient_read_error() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("logs").join("logs.db");
+
+        let store = LogStoreHandle::spawn(
+            db_path.clone(),
+            Duration::from_millis(5),
+            DEFAULT_BATCH_SIZE,
+            StorageMode::Local,
+            None,
+            None,
+            Duration::from_secs(3600),
+        );
+
+        let reader = ScriptedReader {
+            steps: VecDeque::from(vec![
+                Ok(b"before_error\n".as_slice()),
+                Err(std::io::Error::new(std::io::ErrorKind::Other, "transient pipe error")),
+                Ok(b"after_error\n".as_slice()),
+            ]),
+        };
+
+        let handle = spawn_capture_task(
+            Some(reader),
+            Some(store.clone()),
+            "svc".to_string(),
+            "info",
+            None,
+            true,  // should_store
+            false, // log_to_tracing
+            None,  // output_capture
+        );
+        let _ = handle.await;
+        store.wait_flush_sync();
+
+        let log_reader = SqliteLogReader::new(db_path, StorageMode::Local);
+        let lines: Vec<String> = log_reader
+            .tail(100, &["svc".to_string()], false, None, None, None)
+            .into_iter()
+            .map(|e| e.line)
+            .collect();
+
+        assert!(
+            lines.iter().any(|l| l == "before_error"),
+            "line before the error should be captured; got {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l == "after_error"),
+            "line AFTER a transient read error must still be captured \
+             (capture must retry, not end); got {lines:?}"
+        );
+    }
+
+    /// A transient read error that lands MID-LINE must not split or drop the
+    /// line: the partial bytes already read are preserved and the retry
+    /// completes the line, so it is stored whole.
+    #[tokio::test]
+    async fn capture_preserves_partial_line_across_mid_line_read_error() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("logs").join("logs.db");
+
+        let store = LogStoreHandle::spawn(
+            db_path.clone(),
+            Duration::from_millis(5),
+            DEFAULT_BATCH_SIZE,
+            StorageMode::Local,
+            None,
+            None,
+            Duration::from_secs(3600),
+        );
+
+        // "partial_" arrives, then a transient error mid-line, then "rest\n".
+        let reader = ScriptedReader {
+            steps: VecDeque::from(vec![
+                Ok(b"partial_".as_slice()),
+                Err(std::io::Error::new(std::io::ErrorKind::Other, "transient mid-line")),
+                Ok(b"rest\n".as_slice()),
+            ]),
+        };
+
+        let handle = spawn_capture_task(
+            Some(reader),
+            Some(store.clone()),
+            "svc".to_string(),
+            "info",
+            None,
+            true,
+            false,
+            None,
+        );
+        let _ = handle.await;
+        store.wait_flush_sync();
+
+        let log_reader = SqliteLogReader::new(db_path, StorageMode::Local);
+        let lines: Vec<String> = log_reader
+            .tail(100, &["svc".to_string()], false, None, None, None)
+            .into_iter()
+            .map(|e| e.line)
+            .collect();
+
+        assert!(
+            lines.iter().any(|l| l == "partial_rest"),
+            "a mid-line read error must not split the line; expected 'partial_rest', got {lines:?}"
+        );
+        assert!(
+            !lines.iter().any(|l| l == "rest"),
+            "the line must not be split into a truncated 'rest'; got {lines:?}"
+        );
+    }
 }

--- a/kepler-daemon/src/process/tests.rs
+++ b/kepler-daemon/src/process/tests.rs
@@ -1,5 +1,125 @@
 use super::*;
 
+// ============================================================================
+// Log capture robustness
+//
+// Regression tests for a bug where a single invalid-UTF-8 byte on a captured
+// stdout/stderr stream permanently killed log capture for that stream: the
+// capture loop is `while let Ok(Some(line)) = lines.next_line().await`, which
+// treats an `Err` (e.g. ErrorKind::InvalidData from non-UTF-8 input) the same
+// as clean EOF, silently ending the loop. Everything emitted after the bad
+// byte is then never stored or streamed.
+// ============================================================================
+
+use crate::config::StorageMode;
+use crate::logs::{DEFAULT_BATCH_SIZE, LogLine, LogStoreHandle, SqliteLogReader};
+use std::collections::HashMap;
+use std::time::Duration;
+use tempfile::TempDir;
+
+/// Run `script` under `/bin/sh -c` with full log capture, then return all
+/// captured log lines for service "svc" (chronological order).
+///
+/// Uses `BlockingMode::WithLogging` because it awaits the process AND the
+/// capture tasks to completion, making the assertion deterministic with no
+/// dependency on the flush interval. The spec is built directly (not via
+/// `CommandSpec::new`) so `no_new_privileges` stays `false` and the
+/// `kepler-exec` wrapper — which may be absent under `cargo test` — is not
+/// required.
+async fn capture_script_lines(script: &str) -> Vec<LogLine> {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("logs").join("logs.db");
+
+    let store = LogStoreHandle::spawn(
+        db_path.clone(),
+        Duration::from_millis(10),
+        DEFAULT_BATCH_SIZE,
+        StorageMode::Local,
+        None,
+        None,
+        Duration::from_secs(3600),
+    );
+
+    let spec = CommandSpec {
+        program_and_args: vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            script.to_string(),
+        ],
+        working_dir: dir.path().to_path_buf(),
+        environment: HashMap::new(),
+        user: None,
+        groups: vec![],
+        limits: None,
+        clear_env: false,
+        no_new_privileges: false,
+    };
+
+    let result = spawn_blocking(
+        spec,
+        BlockingMode::WithLogging {
+            log_store: Some(store.clone()),
+            log_service_name: "svc".to_string(),
+            hook: None,
+            store_stdout: true,
+            store_stderr: true,
+            output_capture: None,
+        },
+    )
+    .await
+    .expect("spawn_blocking should succeed");
+    // sanity: the script itself exits cleanly
+    assert_eq!(result.exit_code, Some(0), "test script should exit 0");
+
+    store.wait_flush_sync();
+
+    let reader = SqliteLogReader::new(db_path, StorageMode::Local);
+    reader.tail(1000, &["svc".to_string()], false, None, None, None)
+}
+
+/// A line emitted on stdout AFTER an invalid-UTF-8 line must still be captured.
+#[tokio::test]
+async fn capture_survives_invalid_utf8_on_stdout() {
+    // 0xFF 0xFE is not valid UTF-8. printf emits it via octal escapes.
+    let lines = capture_script_lines(
+        "printf 'BEFORE_UTF8\\n'; printf '\\377\\376 garbage\\n'; printf 'AFTER_UTF8\\n'",
+    )
+    .await;
+
+    let texts: Vec<&str> = lines.iter().map(|e| e.line.as_str()).collect();
+    assert!(
+        texts.iter().any(|l| l.contains("BEFORE_UTF8")),
+        "line before the invalid byte should be captured. Got: {texts:?}"
+    );
+    assert!(
+        texts.iter().any(|l| l.contains("AFTER_UTF8")),
+        "line AFTER the invalid-UTF-8 byte must still be captured \
+         (a bad byte must not kill the stream). Got: {texts:?}"
+    );
+}
+
+/// Same guarantee for stderr (captured at level "error").
+#[tokio::test]
+async fn capture_survives_invalid_utf8_on_stderr() {
+    let lines = capture_script_lines(
+        "printf 'BEFORE_ERR\\n' >&2; printf '\\377\\376 garbage\\n' >&2; printf 'AFTER_ERR\\n' >&2",
+    )
+    .await;
+
+    let after = lines.iter().find(|e| e.line.contains("AFTER_ERR"));
+    assert!(
+        after.is_some(),
+        "line AFTER the invalid-UTF-8 byte on stderr must still be captured. \
+         Got: {:?}",
+        lines.iter().map(|e| e.line.as_str()).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        &*after.unwrap().level,
+        "error",
+        "stderr lines should be stored at level error"
+    );
+}
+
 #[test]
 fn test_parse_signal_name_with_sig_prefix() {
     assert_eq!(parse_signal_name("SIGTERM"), Some(15));

--- a/kepler-protocol/Cargo.toml
+++ b/kepler-protocol/Cargo.toml
@@ -20,6 +20,7 @@ dashmap = "6.1.0"
 
 [dev-dependencies]
 tempfile = "3.10"
+serde_json = "1.0"
 
 # Unix-specific functionality
 [target.'cfg(unix)'.dependencies]

--- a/kepler-protocol/src/protocol.rs
+++ b/kepler-protocol/src/protocol.rs
@@ -431,6 +431,12 @@ pub struct ConfigStatus {
     pub config_hash: String,
     /// Services in this config
     pub services: HashMap<String, ServiceInfo>,
+    /// True when the log-store writer is currently unable to persist logs —
+    /// every flush is failing even after reopening the connection (e.g. a
+    /// persistent NFS/disk error). `#[serde(default)]` keeps older clients and
+    /// snapshots compatible.
+    #[serde(default)]
+    pub log_degraded: bool,
 }
 
 /// Information about a loaded config

--- a/kepler-protocol/src/protocol/tests.rs
+++ b/kepler-protocol/src/protocol/tests.rs
@@ -855,3 +855,35 @@ fn roundtrip_recreate_with_define_flags() {
         _ => panic!("Expected Recreate request"),
     }
 }
+
+// ========================================================================
+// ConfigStatus.log_degraded backward compatibility
+// ========================================================================
+
+/// A `ConfigStatus` payload from an older daemon (no `log_degraded` key) must
+/// still deserialize, defaulting `log_degraded` to false.
+#[test]
+fn config_status_deserializes_without_log_degraded() {
+    let json = r#"{
+        "config_path": "/app/kepler.yaml",
+        "config_hash": "abc123",
+        "services": {}
+    }"#;
+    let parsed: ConfigStatus = serde_json::from_str(json).unwrap();
+    assert_eq!(parsed.config_path, "/app/kepler.yaml");
+    assert!(!parsed.log_degraded, "missing log_degraded must default to false");
+}
+
+/// `log_degraded` round-trips when present.
+#[test]
+fn config_status_roundtrips_log_degraded() {
+    let status = ConfigStatus {
+        config_path: "/app/kepler.yaml".to_string(),
+        config_hash: "abc123".to_string(),
+        services: std::collections::HashMap::new(),
+        log_degraded: true,
+    };
+    let json = serde_json::to_string(&status).unwrap();
+    let parsed: ConfigStatus = serde_json::from_str(&json).unwrap();
+    assert!(parsed.log_degraded);
+}

--- a/kepler-tests/tests/log_capture_tests.rs
+++ b/kepler-tests/tests/log_capture_tests.rs
@@ -1,0 +1,85 @@
+//! Log-capture robustness tests.
+//!
+//! Regression coverage for a production bug where a single invalid-UTF-8 byte
+//! on a service's captured stdout/stderr permanently stopped log capture for
+//! that stream: the capture loop is
+//! `while let Ok(Some(line)) = lines.next_line().await`, which treats an `Err`
+//! (e.g. `ErrorKind::InvalidData` from non-UTF-8 input) the same as clean EOF
+//! and silently ends. Everything emitted after the bad byte is then never
+//! stored in the SQLite log DB nor streamed to clients.
+
+use kepler_daemon::logs::SqliteLogReader;
+use kepler_tests::helpers::config_builder::{TestConfigBuilder, TestServiceBuilder};
+use kepler_tests::helpers::daemon_harness::TestDaemonHarness;
+use std::time::Duration;
+use tempfile::TempDir;
+
+/// A real service that prints a valid line, then an invalid-UTF-8 line, then
+/// another valid line, then stays alive. The line after the bad byte must
+/// still reach the SQLite log store.
+#[tokio::test]
+async fn service_log_capture_survives_invalid_utf8() {
+    let temp_dir = TempDir::new().unwrap();
+
+    // 0xFF 0xFE (octal \377 \376) is not valid UTF-8. `sleep` keeps the
+    // service in the Running state so capture is exercised on a live process.
+    let script = "printf 'BEFORE_UTF8\\n'; \
+                  printf '\\377\\376 garbage\\n'; \
+                  printf 'AFTER_UTF8\\n'; \
+                  sleep 30";
+
+    let config = TestConfigBuilder::new()
+        .add_service(
+            "utf8svc",
+            TestServiceBuilder::new(vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                script.to_string(),
+            ])
+            .build(),
+        )
+        .build();
+
+    let harness = TestDaemonHarness::new(config, temp_dir.path())
+        .await
+        .unwrap();
+
+    harness.start_service("utf8svc").await.unwrap();
+
+    let log_store = harness
+        .handle()
+        .get_log_store()
+        .await
+        .expect("log store should exist");
+    let db_path = log_store.db_path().to_path_buf();
+    let storage_mode = log_store.storage_mode();
+
+    // Poll up to ~8s: the capture task reads from the pipe asynchronously, so
+    // wait_flush_sync() alone isn't enough — we flush + re-read until the
+    // post-bad-byte line shows up (or give up, reproducing the bug).
+    let mut last_seen: Vec<String> = Vec::new();
+    let mut found_after = false;
+    for _ in 0..80 {
+        log_store.wait_flush_sync();
+        let reader = SqliteLogReader::new(db_path.clone(), storage_mode);
+        let entries = reader.tail(1000, &["utf8svc".to_string()], false, None, None, None);
+        last_seen = entries.iter().map(|e| e.line.clone()).collect();
+        if last_seen.iter().any(|l| l.contains("AFTER_UTF8")) {
+            found_after = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    assert!(
+        last_seen.iter().any(|l| l.contains("BEFORE_UTF8")),
+        "line before the invalid byte should be captured. Got: {last_seen:?}"
+    );
+    assert!(
+        found_after,
+        "line AFTER the invalid-UTF-8 byte must still be captured \
+         (a bad byte must not permanently kill the stream). Got: {last_seen:?}"
+    );
+
+    let _ = harness.stop_service("utf8svc").await;
+}


### PR DESCRIPTION
## What does this PR do?

Fixes three related causes of **silent log/metric data loss** on the SQLite log
and metrics stores ÔÇö all of which manifest as "logs (or metrics) just stop,
permanently, until the daemon/service restarts." They surface most readily in a
GVisor sandbox with state on NFS, but two of the three are environment-agnostic.

### 1\. Persistent write errors silently dropped every batch forever (log store + monitor)

Both the log-store actor and the monitor-writer actor would catch a flush error,
log a warning, drop the in-flight batch, and continue ÔÇö but **never reopen the**
**connection**. An NFS stale file handle (ESTALE) poisons the open file descriptor
permanently until it is closed and reopened, so every subsequent flush failed the
same way, silently dropping all logs/metrics from that point on until restart.

The fix adds a **reopen-and-retry loop** (`MAX_FLUSH_REOPEN_ATTEMPTS = 3`) to both
actors:

- The in-flight batch is **not drained until a commit succeeds**, so a successful
retry after reopen preserves the data that was in flight during the fault.
- On reopen, the shared SQLite interrupt handle (used by `shutdown_discard()`) is
**refreshed** to point at the new live connection.
- If all attempts fail, the batch is dropped and a **degraded flag** is raised on
the log-store handle, making the failure observable via
`LogStoreHandle::is_degraded()` instead of silent.

### 2\. A single invalid-UTF-8 byte permanently killed log capture for a stream

`spawn_capture_task` / `spawn_drain_task` / `spawn_collect_task` previously read
lines via `AsyncBufReadExt::lines()`, which returns `Err` on any invalid-UTF-8
byte. The `while let Ok(Some(...))` pattern treats that `Err` identically to clean
EOF, so a single bad byte (binary output, a non-UTF-8 locale byte, a truncated
multibyte sequence, etc.) **permanently ended capture** for that stream ÔÇö the
service kept running while its logs stopped, in both the stream and the DB.

The loops now read raw bytes via `read_until(b'\n', ...)` and lossily decode each
line, so a bad byte becomes a `U+FFFD` replacement character instead of killing
the stream.

### 3\. A transient read error ended capture instead of retrying

After fix #2 the capture loop still `break`s on a genuine `Err` from
`read_until`. Because a read error does not close the pipe fd, the loop now
**retries on the same fd** with a bounded cap (`MAX_CAPTURE_READ_RETRIES = 5`
consecutive errors) and a 50 ms backoff, only giving up after the cap is
exhausted. This is defense-in-depth ÔÇö most relevant under GVisor, whose syscall
emulation is likelier to surface a spurious transient errno than a native kernel.

## Other changes

- **Observability wiring for** **`is_degraded()`:**
    - `kepler inspect` base JSON now always includes `"logs": { "degraded": <bool> }`.
    - `ConfigStatus` (the multi-config `kepler status` response) gains a
`#[serde(default)] log_degraded: bool` field, populated in both daemon
constructors; the CLI prints a `ÔÜá  Log persistence DEGRADED ÔÇª` line under the
status table when set.
- Adds `SharedFlags` (Arc-backed atomics for `degraded` and a `#[cfg(test)]`
`inject_fail_until_reopen`) shared between the log-store actor and its handles.
- Adds `LogStoreHandle::is_degraded()` to surface persistence health to callers.
- Adds `strip_trailing_newline` to replicate the `\r\n` / `\n` trimming that
`lines()` previously performed.
- Genuine I/O errors in the capture loop are now logged (`warn!`) before the loop
ends, rather than silently swallowed.
- Flush errors are logged at `error!` (dropped batch) / `info!` (recovered) with
attempt counts, instead of a single ambiguous `warn!`.
- Adds `serde_json` as a `kepler-protocol` dev-dependency (for the new tests).

## How to test

New tests (each written test-first and verified red ÔåÆ green):

- `logs::store::tests::flush_recovers_by_reopening_after_persistent_write_error` ÔÇö
injects a simulated stale-fd fault via `test_inject_fail_until_reopen()`,
verifies the in-flight batch is retried and persisted, a subsequent batch also
lands, and `is_degraded()` returns false after recovery.
- `process::tests::capture_survives_invalid_utf8_on_stdout` /
`ÔÇª_on_stderr` ÔÇö a shell script emits a valid line, an invalid-UTF-8 line
(`\xFF\xFE`), then another valid line; asserts the post-bad-byte line is stored.
- `process::spawn::tests::capture_recovers_from_transient_read_error` ÔÇö a
`ScriptedReader` mock (`AsyncRead`) yields a line, a transient `Err`, then
another line; asserts the post-error line is still captured (retry, not break).
- `kepler_tests::log_capture_tests::service_log_capture_survives_invalid_utf8` ÔÇö
end-to-end: runs a real service through the daemon harness with the
invalid-UTF-8 script and polls the SQLite log DB for the post-bad-byte line.
- `protocol::tests::config_status_deserializes_without_log_degraded` /
`config_status_roundtrips_log_degraded` ÔÇö backward-compat for the new
`log_degraded` field.