### PR TITLE
Fix log streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-cli"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "arboard",
  "chrono",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-daemon"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-e2e"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "pretty_assertions",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-exec"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "kepler-unix",
  "libc",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-protocol"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "bincode",
  "dashmap 6.1.0",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-tests"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "dashmap 5.5.3",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "kepler-unix"
-version = "0.15.4"
+version = "0.16.0"
 dependencies = [
  "libc",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.4"
+version = "0.16.0"
 
 [profile.release]
 strip = true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -713,10 +713,17 @@ For follow mode, the client subscribes to `SubscribeLogs` notifications and issu
 **Modes:**
 | Mode   | CLI Flag   | Behavior                                |
 | ------ | ---------- | --------------------------------------- |
-| head   | `--head`   | Return first N lines (one-shot)         |
-| tail   | `--tail`   | Return last N lines (one-shot)          |
+| head   | `--head`   | Return the first N entries, then exit   |
+| tail   | `--tail`   | Return the last N entries, then exit    |
 | all    | (default)  | Stream all existing logs, then exit     |
 | follow | `--follow` | Stream existing + new logs continuously |
+
+All four modes share the `after_id` cursor loop above. `--head N` and `--tail N`
+cap the total entries the client prints; they are not per-response sizes. A tail
+request resolves the start of the "last N" window server-side
+(`LogReader::tail_start_id`) and the client pages forward from there, so only the
+first request sets the `tail` flag. Responses are capped at
+`STREAM_CHUNK_SIZE` entries so a large count never builds one oversized frame.
 
 ### Relevant Files
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -458,8 +458,8 @@ kepler logs -F "level = 'err'" --sql   # Raw SQL filter
 | Flag                  | Description                                                                        |
 | --------------------- | ---------------------------------------------------------------------------------- |
 | `--follow`            | Stream new logs continuously                                                       |
-| `--head <N>`          | Show first N lines                                                                 |
-| `--tail <N>`          | Show last N lines                                                                  |
+| `--head <N>`          | Print the first N entries, then exit (applied after `--filter`)                    |
+| `--tail <N>`          | Print the last N entries, then exit (applied after `--filter`)                     |
 | `--no-hook`           | Exclude hook log output                                                            |
 | `--raw`               | Output raw log lines without formatting (no timestamp, level, service name, color) |
 | `-F, --filter <EXPR>` | Filter logs using a [search expression](log-management.md#log-filtering)           |

--- a/docs/log-management.md
+++ b/docs/log-management.md
@@ -184,8 +184,16 @@ kepler logs backend             # Logs for a specific service
 |------|----------|----------|
 | All | (default) | Stream all existing logs, then exit |
 | Follow | `--follow` | Stream existing + new logs continuously |
-| Head | `--head N` | Return first N lines (one-shot) |
-| Tail | `--tail N` | Return last N lines (one-shot) |
+| Head | `--head N` | Return the first N entries, then exit |
+| Tail | `--tail N` | Return the last N entries, then exit |
+
+`--head` and `--tail` bound the total number of entries printed, not the size of
+each fetch. Any filter is applied first, so `--tail 20 -F '@level:error'` returns
+the last 20 *matching* entries. Large counts are fetched in chunks and streamed
+as they arrive rather than assembled into a single response.
+
+Combined with `--follow`, the count only sizes the initial window: `kepler logs
+--follow --tail 20` prints the last 20 entries and then keeps streaming.
 
 Logs from multiple services are merged chronologically and displayed with service-colored output.
 
@@ -239,6 +247,8 @@ All field matching requires the `@` prefix. Reserved field names map directly to
 | `@level` | `level` | `@level:error` |
 | `@message` | `line` | `@message:hello` |
 | `@hook` | `hook` | `@hook:pre_start` |
+| `@timestamp` | `timestamp` | `@timestamp:>1753600000000` |
+| `@id` | `id` | `@id:>41230` |
 
 Field names are case-insensitive (`@Service:web` and `@SERVICE:web` both work).
 
@@ -246,6 +256,15 @@ Field names are case-insensitive (`@Service:web` and `@SERVICE:web` both work).
 kepler logs -F '@service:web'               # logs from the "web" service
 kepler logs -F '@level:err'                 # stderr logs only
 kepler logs -F '@hook:pre_start'            # logs from the pre_start hook
+```
+
+`@id` is the row ID: unique and monotonically increasing, unlike `@timestamp`, which
+can repeat within the same millisecond. It is emitted as `id` by `kepler logs --json`,
+which makes it the cursor to use for pagination:
+
+```bash
+kepler logs --head 50 -F '@level:error' --json              # first page
+kepler logs --head 50 -F '@level:error AND @id:>41230' --json  # next page, cursor = last id
 ```
 
 ### Attribute Search

--- a/examples/complex.kepler.yaml
+++ b/examples/complex.kepler.yaml
@@ -55,11 +55,15 @@ kepler:
     interval: 1s # Sample every 5 seconds
     retention_period: 24h # Keep 24 hours of history (omit to keep forever)
   logs:
+    retention_period: "7d"
     retention:
-      on_stop: clear
-      on_start: clear
-      on_restart: clear
-      on_exit: clear
+      # Keep everything in memory unless the config is started fresh which only happens
+      # If it was stopped then started
+      on_start: retain
+      on_skipped: retain
+      on_stop: retain
+      on_restart: retain
+      on_exit: retain
 
 services:
   # ═══════════════════════════════════════════════════════════════════════════

--- a/kepler-cli/src/main.rs
+++ b/kepler-cli/src/main.rs
@@ -227,7 +227,7 @@ async fn run() -> Result<()> {
                 )?;
                 let response = run_with_progress(progress_rx, restart_future).await?;
                 handle_response(response);
-                match handle_logs(&client, canonical_path, log_services, true, kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, false, false, raw_output, false, None, false).await {
+                match handle_logs(&client, canonical_path, log_services, true, None, false, false, raw_output, false, None, false).await {
                     Ok(()) => {}
                     Err(CliError::PermissionDenied(_)) => {
                         if !cli.quiet {
@@ -270,11 +270,11 @@ async fn run() -> Result<()> {
             sql,
         } => {
             let (is_tail, lines) = if let Some(n) = head {
-                (false, n)
+                (false, Some(n))
             } else if let Some(n) = tail {
-                (true, n)
+                (true, Some(n))
             } else {
-                (false, kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE)
+                (false, None)
             };
             handle_logs(&client, canonical_path, services, follow, lines, is_tail, no_hook, raw_output, json_output, filter, sql).await?;
         }
@@ -1476,8 +1476,12 @@ struct StreamParams<'a> {
     sql: bool,
     /// Raw mode: only fetch and output log line content.
     raw: bool,
-    /// Tail mode: return last `limit` entries (one-shot).
+    /// Tail mode: the window is the last `limit` entries. The first request
+    /// resolves that window server-side; the rest page forward from it.
     tail: bool,
+    /// Stop after this many entries in total (`--head N` / `--tail N`).
+    /// `None` drains until the stream ends — the default for `kepler logs`.
+    max_total: Option<usize>,
 }
 
 /// Unified log streaming loop with client-side position tracking.
@@ -1504,8 +1508,18 @@ async fn stream_logs(
     tokio::pin!(shutdown);
     tokio::pin!(quiescence);
     let mut quiescent_received = false;
+    let mut remaining = params.max_total;
 
     loop {
+        // Only the first request is a tail request: it resolves the window.
+        // Once we have a cursor, we page forward like any other read.
+        let tail_request = params.tail && last_id.is_none();
+        // Don't ask for more than we're allowed to print.
+        let request_limit = match remaining {
+            Some(n) if !tail_request => n.min(params.limit),
+            _ => params.limit,
+        };
+
         // Select with shutdown so Ctrl+C is responsive even if the daemon
         // has disconnected and the logs_stream call would hang.
         // Timeout prevents indefinite stall if a response is lost or delayed.
@@ -1518,8 +1532,8 @@ async fn stream_logs(
                 Duration::from_secs(5),
                 client.logs_stream(
                     params.config_path, params.services, last_id,
-                    from_end && last_id.is_none(), params.limit, params.no_hooks,
-                    params.filter, params.sql, params.raw, params.tail,
+                    from_end && last_id.is_none(), request_limit, params.no_hooks,
+                    params.filter, params.sql, params.raw, tail_request,
                     None, None,
                 ),
             ) => match result {
@@ -1537,18 +1551,31 @@ async fn stream_logs(
                 Response::Ok {
                     data: Some(ResponseData::LogStream(LogStreamData {
                         service_table,
-                        entries,
+                        mut entries,
                         last_id: new_last_id,
                         has_more,
                     })),
                     ..
                 } => {
                     last_id = Some(new_last_id);
+                    // A batch can overshoot the total when the server rounds up
+                    // to its own chunk size — print only what we still owe.
+                    let exhausted = match remaining {
+                        Some(n) => {
+                            entries.truncate(n);
+                            remaining = Some(n - entries.len());
+                            entries.len() == n
+                        }
+                        None => false,
+                    };
                     // has_more but empty entries means data is pending flush —
                     // treat as "no more readable data" so we wait for notification
                     has_more_data = has_more && !entries.is_empty();
                     if !entries.is_empty() {
                         on_batch(&service_table, &entries);
+                    }
+                    if exhausted {
+                        break;
                     }
                 }
                 Response::PermissionDenied { .. } => {
@@ -1710,6 +1737,8 @@ fn write_log_batch_json(service_table: &[Arc<str>], entries: &[StreamLogEntry]) 
     for entry in entries {
         let service_name = &service_table[entry.service_id as usize];
         let mut obj = serde_json::Map::new();
+        // Row ID — stable, monotonic cursor for pagination (`--sql -F 'id > <last>'`).
+        obj.insert("id".into(), serde_json::Value::from(entry.id));
         if let Some(dt) = DateTime::<Utc>::from_timestamp_millis(entry.timestamp) {
             obj.insert("timestamp".into(), serde_json::Value::String(
                 dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
@@ -1842,6 +1871,7 @@ async fn follow_logs_until_quiescent(
             sql: false,
             raw,
             tail: false,
+            max_total: None,
         },
         async { let _ = tokio::signal::ctrl_c().await; },
         quiescence_wrapper,
@@ -1954,7 +1984,8 @@ async fn handle_logs(
     config_path: PathBuf,
     services: Vec<String>,
     follow: bool,
-    lines: usize,
+    // Explicit `--head N` / `--tail N` count. `None` = no limit.
+    lines: Option<usize>,
     tail: bool,
     no_hooks: bool,
     raw: bool,
@@ -1968,6 +1999,11 @@ async fn handle_logs(
     let mut cached_ts_str = String::new();
 
     let stream_mode = if follow { StreamMode::UntilQuiescent } else { StreamMode::All };
+
+    // `--head N` / `--tail N` are one-shot: stop once N entries are printed.
+    // When following, N only sizes the initial window — the stream continues.
+    let max_total = if follow { None } else { lines };
+    let limit = lines.unwrap_or(kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE);
 
     // Subscribe to log-available notifications for follow modes
     let log_notify_rx = if stream_mode != StreamMode::All {
@@ -1983,11 +2019,12 @@ async fn handle_logs(
             services: &services,
             no_hooks,
             mode: stream_mode,
-            limit: lines,
+            limit,
             filter: filter.as_deref(),
             sql,
             raw,
             tail,
+            max_total,
         },
         std::future::pending(),
         std::future::pending(),

--- a/kepler-cli/src/main.rs
+++ b/kepler-cli/src/main.rs
@@ -217,6 +217,9 @@ async fn run() -> Result<()> {
             } else if follow {
                 // --follow: Progress bars then log following (Ctrl+C just exits, services keep running)
                 let log_services = services.clone();
+                // Anchor before restarting: the restart is awaited below, so by the
+                // time streaming starts the new services have already logged.
+                let log_start = current_log_end(&client, &canonical_path).await;
                 let (progress_rx, restart_future) = client.restart(
                     canonical_path.clone(),
                     services,
@@ -227,7 +230,7 @@ async fn run() -> Result<()> {
                 )?;
                 let response = run_with_progress(progress_rx, restart_future).await?;
                 handle_response(response);
-                match handle_logs(&client, canonical_path, log_services, true, None, false, false, raw_output, false, None, false).await {
+                match handle_logs(&client, canonical_path, log_services, true, None, false, false, raw_output, false, None, false, log_start).await {
                     Ok(()) => {}
                     Err(CliError::PermissionDenied(_)) => {
                         if !cli.quiet {
@@ -276,7 +279,7 @@ async fn run() -> Result<()> {
             } else {
                 (false, None)
             };
-            handle_logs(&client, canonical_path, services, follow, lines, is_tail, no_hook, raw_output, json_output, filter, sql).await?;
+            handle_logs(&client, canonical_path, services, follow, lines, is_tail, no_hook, raw_output, json_output, filter, sql, None).await?;
         }
 
         Commands::PS { json, .. } => {
@@ -620,14 +623,17 @@ async fn handle_launch(
         let response = fut.await?;
         handle_response(response);
     } else {
-        // Foreground: inline quiescence detection + log streaming
+        // Foreground: inline quiescence detection + log streaming.
+        // Anchor the stream at the current end of the log *before* launching, so
+        // previous runs aren't replayed and no startup output is missed.
+        let log_start = current_log_end(client, &canonical_path).await;
         let (progress_rx, fut) = send_launch_request(
             client, canonical_path.clone(), args.services.clone(), sys_env,
             args.no_deps, override_envs, args.hardening, true, &mode, define_flags.clone(),
         )?;
         foreground_with_logs(
             fut,
-            follow_logs_until_quiescent(client, &canonical_path, &args.services, args.abort_on_failure, progress_rx, args.raw, args.json, quiet),
+            follow_logs_until_quiescent(client, &canonical_path, &args.services, args.abort_on_failure, progress_rx, args.raw, args.json, quiet, log_start),
         ).await?;
 
         // run --clean: remove entire state dir after all services exit
@@ -1437,6 +1443,37 @@ impl FollowClient for Client {
     }
 }
 
+/// Current end of the log, for anchoring a follow stream to "from here on".
+///
+/// Logs persist across runs, so a stream that starts at ID 0 replays every
+/// previous run. Callers capture this *before* launching services — anchoring
+/// once the stream is already running would race with startup output and drop
+/// the lines that matter most.
+///
+/// `None` means the position is unknown (no logs yet, config not loaded,
+/// permission denied); the caller then streams from the beginning as before.
+async fn current_log_end(client: &Client, config_path: &Path) -> Option<i64> {
+    let (_rx, fut) = Client::logs_stream(
+        client, config_path, &[], None, /* from_end */ true, 1,
+        false, None, false, /* raw */ true, false, None, None,
+    ).ok()?;
+    match fut.await.ok()? {
+        Response::Ok {
+            data: Some(ResponseData::LogStream(LogStreamData { last_id, .. })),
+            ..
+        } => Some(last_id),
+        _ => None,
+    }
+}
+
+/// How often a one-shot stream re-checks for entries still buffered by the
+/// daemon's writer actor (default flush interval is 100ms, configurable).
+const FLUSH_WAIT_POLL: Duration = Duration::from_millis(25);
+
+/// Upper bound on that wait (~2s) so a service logging continuously can't keep
+/// a one-shot `kepler logs` running forever.
+const MAX_FLUSH_WAITS: u32 = 80;
+
 /// Streaming mode.
 #[derive(Clone, Copy, PartialEq)]
 enum StreamMode {
@@ -1482,6 +1519,9 @@ struct StreamParams<'a> {
     /// Stop after this many entries in total (`--head N` / `--tail N`).
     /// `None` drains until the stream ends — the default for `kepler logs`.
     max_total: Option<usize>,
+    /// Start the stream after this entry ID instead of at the beginning.
+    /// Used by attached start/restart to skip logs from previous runs.
+    start_after_id: Option<i64>,
 }
 
 /// Unified log streaming loop with client-side position tracking.
@@ -1504,11 +1544,12 @@ async fn stream_logs(
     mut on_batch: impl FnMut(&[Arc<str>], &[StreamLogEntry]),
 ) -> Result<StreamExitReason> {
     let from_end = params.mode == StreamMode::Follow;
-    let mut last_id: Option<i64> = None;
+    let mut last_id: Option<i64> = params.start_after_id;
     tokio::pin!(shutdown);
     tokio::pin!(quiescence);
     let mut quiescent_received = false;
     let mut remaining = params.max_total;
+    let mut flush_waits: u32 = 0;
 
     loop {
         // Only the first request is a tail request: it resolves the window.
@@ -1546,6 +1587,10 @@ async fn stream_logs(
         };
 
         let has_more_data;
+        // Server reports more data but returned nothing: entries are written but
+        // still buffered by the writer actor. One-shot modes wait for the flush
+        // rather than exiting and losing them.
+        let mut pending_flush = false;
         match log_response {
             Ok(response) => match response {
                 Response::Ok {
@@ -1571,6 +1616,7 @@ async fn stream_logs(
                     // has_more but empty entries means data is pending flush —
                     // treat as "no more readable data" so we wait for notification
                     has_more_data = has_more && !entries.is_empty();
+                    pending_flush = has_more && entries.is_empty();
                     if !entries.is_empty() {
                         on_batch(&service_table, &entries);
                     }
@@ -1625,8 +1671,23 @@ async fn stream_logs(
         match params.mode {
             StreamMode::All => {
                 if !has_more_data {
+                    // Entries are buffered in the writer actor and would be lost
+                    // if we exited now — give the flush a bounded chance to land.
+                    // Follow modes don't need this: they get a LogsAvailable event.
+                    if pending_flush && flush_waits < MAX_FLUSH_WAITS {
+                        flush_waits += 1;
+                        tokio::select! {
+                            biased;
+                            _ = &mut shutdown => {
+                                return Ok(StreamExitReason::ShutdownRequested);
+                            }
+                            _ = tokio::time::sleep(FLUSH_WAIT_POLL) => continue,
+                        }
+                    }
                     break;
                 }
+                // Progress was made — a later stall gets a fresh budget.
+                flush_waits = 0;
             }
             StreamMode::Follow | StreamMode::UntilQuiescent => {
                 // After quiescence signaled and all logs drained, exit.
@@ -1811,6 +1872,9 @@ async fn follow_logs_until_quiescent(
     raw: bool,
     json: bool,
     quiet: bool,
+    // End of the log before this run started — entries at or below it belong to
+    // previous runs and are not streamed.
+    start_after_id: Option<i64>,
 ) -> Result<()> {
     let use_color = !raw && !json && colored::control::SHOULD_COLORIZE.should_colorize();
     let mut color_map: HashMap<String, Color> = HashMap::new();
@@ -1872,6 +1936,7 @@ async fn follow_logs_until_quiescent(
             raw,
             tail: false,
             max_total: None,
+            start_after_id,
         },
         async { let _ = tokio::signal::ctrl_c().await; },
         quiescence_wrapper,
@@ -1992,6 +2057,9 @@ async fn handle_logs(
     json: bool,
     filter: Option<String>,
     sql: bool,
+    // Skip entries at or below this ID. `None` streams from the beginning,
+    // which is what `kepler logs [--follow]` wants.
+    start_after_id: Option<i64>,
 ) -> Result<()> {
     let use_color = !raw && !json && colored::control::SHOULD_COLORIZE.should_colorize();
     let mut color_map: HashMap<String, Color> = HashMap::new();
@@ -2025,6 +2093,7 @@ async fn handle_logs(
             raw,
             tail,
             max_total,
+            start_after_id,
         },
         std::future::pending(),
         std::future::pending(),

--- a/kepler-cli/src/tests.rs
+++ b/kepler-cli/src/tests.rs
@@ -148,7 +148,7 @@ async fn test_follow_reads_and_exits_on_quiescence() {
 
     // Fire quiescence after we've collected 3 lines
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None }, never_shutdown(),
         async { let _ = rx.await; },
         None,
         |st, entries| {
@@ -178,7 +178,7 @@ async fn test_follow_drains_logs_after_quiescence() {
 
     // Quiescence fires immediately — but logs should still be drained
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None }, never_shutdown(),
         async {},  // quiescence fires immediately
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -203,7 +203,7 @@ async fn test_follow_continues_without_quiescence() {
     let mut tx = Some(tx);
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None }, never_shutdown(),
         async { let _ = rx.await; },
         None,
         |st, entries| {
@@ -240,7 +240,7 @@ async fn test_follow_shutdown_stops_reads() {
 
     // Shutdown resolves immediately — the biased select picks it up before the first read
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, async {},
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None }, async {},
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -271,7 +271,7 @@ async fn test_follow_shutdown_after_n_reads() {
 
     // Trigger shutdown after 3 batches are collected
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None },
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None },
         async move { notify_clone.notified().await },
         never_quiescent(),
         None,
@@ -302,7 +302,7 @@ async fn test_follow_daemon_disconnect_exits() {
     let mut collected = Vec::new();
 
     stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None }, never_shutdown(),
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -322,7 +322,7 @@ async fn test_follow_server_error_breaks_loop() {
     let mut collected = Vec::new();
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None }, never_shutdown(),
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -342,7 +342,7 @@ async fn test_stream_logs_permission_denied() {
     let mut collected = Vec::new();
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None }, never_shutdown(),
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -362,7 +362,7 @@ async fn test_stream_logs_non_permission_error_returns_server_error() {
     let mut collected = Vec::new();
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None }, never_shutdown(),
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -385,7 +385,7 @@ async fn run_one_shot(mock: &MockClient, limit: usize, tail: bool, max_total: Op
         StreamParams {
             config_path: &config_path, services: &[], no_hooks: false,
             mode: StreamMode::All, limit, filter: None, sql: false,
-            raw: false, tail, max_total,
+            raw: false, tail, max_total, start_after_id: None,
         },
         never_shutdown(), never_quiescent(), None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -472,7 +472,7 @@ async fn test_follow_empty_exits_on_quiescence() {
     let mut collected = Vec::new();
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None }, never_shutdown(),
         async {},  // quiescence fires immediately
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -493,7 +493,7 @@ async fn test_follow_shutdown_returns_immediately() {
     let mut collected = Vec::new();
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, async {},
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None }, async {},
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -727,7 +727,7 @@ async fn test_follow_config_not_loaded_retries_then_starts() {
     let (tx, rx) = oneshot::channel::<()>();
     let mut tx = Some(tx);
     stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None }, never_shutdown(),
         async { let _ = rx.await; },
         None,
         |st, entries| {
@@ -752,7 +752,7 @@ async fn test_follow_config_not_loaded_exits_on_quiescence() {
     let mut collected = Vec::new();
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None }, never_shutdown(),
         async {},  // quiescence fires immediately (config was unloaded)
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -772,7 +772,7 @@ async fn test_follow_config_not_loaded_shutdown() {
     let mut collected = Vec::new();
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, async {},  // shutdown fires immediately
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None }, async {},  // shutdown fires immediately
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -793,7 +793,7 @@ async fn test_follow_shutdown_handles_starting_services() {
 
     // Shutdown resolves immediately — biased select picks it up before any read
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, async {},
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None }, async {},
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -816,7 +816,7 @@ async fn test_follow_exits_on_quiescence() {
     let (tx, rx) = oneshot::channel::<()>();
     let mut tx = Some(tx);
     stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None, start_after_id: None }, never_shutdown(),
         async { let _ = rx.await; },
         None,
         |st, entries| {
@@ -1028,4 +1028,45 @@ fn test_build_define_flags_duplicate_key_last_wins() {
     let map = result.expect("should be Some");
     assert_eq!(map.get("KEY").unwrap(), "second");
     assert_eq!(map.len(), 1);
+}
+
+/// `start_after_id` seeds the cursor, so the first request skips prior entries
+/// instead of starting at the beginning of the log.
+#[tokio::test(start_paused = true)]
+async fn test_start_after_id_anchors_first_request() {
+    let mock = MockClient::new();
+    mock.push_response(stream_response(&[("svc", "new-1")], false));
+
+    let collected = run_one_shot_anchored(&mock, Some(77)).await;
+
+    assert_eq!(collected, vec!["new-1"]);
+    assert_eq!(mock.calls()[0].0, Some(77), "first request must carry the anchor");
+}
+
+/// Without an anchor the stream starts at the beginning, as `kepler logs` needs.
+#[tokio::test(start_paused = true)]
+async fn test_no_anchor_starts_from_beginning() {
+    let mock = MockClient::new();
+    mock.push_response(stream_response(&[("svc", "old-1")], false));
+
+    let collected = run_one_shot_anchored(&mock, None).await;
+
+    assert_eq!(collected, vec!["old-1"]);
+    assert_eq!(mock.calls()[0].0, None, "first request must have no cursor");
+}
+
+async fn run_one_shot_anchored(mock: &MockClient, start_after_id: Option<i64>) -> Vec<String> {
+    let config_path = PathBuf::from("/fake/config.yaml");
+    let mut collected = Vec::new();
+    stream_logs(
+        mock,
+        StreamParams {
+            config_path: &config_path, services: &[], no_hooks: false,
+            mode: StreamMode::All, limit: 100, filter: None, sql: false,
+            raw: false, tail: false, max_total: None, start_after_id,
+        },
+        never_shutdown(), never_quiescent(), None,
+        |st, entries| collect_batch(&mut collected, st, entries),
+    ).await.unwrap();
+    collected
 }

--- a/kepler-cli/src/tests.rs
+++ b/kepler-cli/src/tests.rs
@@ -5,19 +5,28 @@ use kepler_protocol::protocol::{StreamLogEntry, ProgressEvent};
 
 type ClientResult = std::result::Result<Response, ClientError>;
 
+/// A recorded `logs_stream` call: `(after_id, limit, tail)`.
+type RecordedCall = (Option<i64>, usize, bool);
+
 struct MockClient {
     responses: std::sync::Mutex<VecDeque<ClientResult>>,
+    calls: std::sync::Mutex<Vec<RecordedCall>>,
 }
 
 impl MockClient {
     fn new() -> Self {
         Self {
             responses: std::sync::Mutex::new(VecDeque::new()),
+            calls: std::sync::Mutex::new(Vec::new()),
         }
     }
 
     fn push_response(&self, resp: ClientResult) {
         self.responses.lock().unwrap().push_back(resp);
+    }
+
+    fn calls(&self) -> Vec<RecordedCall> {
+        self.calls.lock().unwrap().clone()
     }
 }
 
@@ -26,17 +35,18 @@ impl FollowClient for MockClient {
         &self,
         _config_path: &Path,
         _services: &[String],
-        _after_id: Option<i64>,
+        after_id: Option<i64>,
         _from_end: bool,
-        _limit: usize,
+        limit: usize,
         _no_hooks: bool,
         _filter: Option<&str>,
         _sql: bool,
         _raw: bool,
-        _tail: bool,
+        tail: bool,
         _after_ts: Option<i64>,
         _before_ts: Option<i64>,
     ) -> std::result::Result<Response, ClientError> {
+        self.calls.lock().unwrap().push((after_id, limit, tail));
         self.responses
             .lock()
             .unwrap()
@@ -50,6 +60,10 @@ impl FollowClient for MockClient {
 // ========================================================================
 
 fn stream_response(entries: &[(&str, &str)], has_more: bool) -> ClientResult {
+    stream_response_with_last_id(entries, has_more, 0)
+}
+
+fn stream_response_with_last_id(entries: &[(&str, &str)], has_more: bool, last_id: i64) -> ClientResult {
     // Build service table and compact entries
     let mut service_table: Vec<Arc<str>> = Vec::new();
     let mut service_map: HashMap<&str, u16> = HashMap::new();
@@ -81,7 +95,7 @@ fn stream_response(entries: &[(&str, &str)], has_more: bool) -> ClientResult {
         LogStreamData {
             service_table,
             entries: compact_entries,
-            last_id: 0,
+            last_id,
             has_more,
         },
     )))
@@ -134,7 +148,7 @@ async fn test_follow_reads_and_exits_on_quiescence() {
 
     // Fire quiescence after we've collected 3 lines
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
         async { let _ = rx.await; },
         None,
         |st, entries| {
@@ -164,7 +178,7 @@ async fn test_follow_drains_logs_after_quiescence() {
 
     // Quiescence fires immediately — but logs should still be drained
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
         async {},  // quiescence fires immediately
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -189,7 +203,7 @@ async fn test_follow_continues_without_quiescence() {
     let mut tx = Some(tx);
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
         async { let _ = rx.await; },
         None,
         |st, entries| {
@@ -226,7 +240,7 @@ async fn test_follow_shutdown_stops_reads() {
 
     // Shutdown resolves immediately — the biased select picks it up before the first read
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false }, async {},
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, async {},
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -257,7 +271,7 @@ async fn test_follow_shutdown_after_n_reads() {
 
     // Trigger shutdown after 3 batches are collected
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false },
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None },
         async move { notify_clone.notified().await },
         never_quiescent(),
         None,
@@ -288,7 +302,7 @@ async fn test_follow_daemon_disconnect_exits() {
     let mut collected = Vec::new();
 
     stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -308,7 +322,7 @@ async fn test_follow_server_error_breaks_loop() {
     let mut collected = Vec::new();
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -328,7 +342,7 @@ async fn test_stream_logs_permission_denied() {
     let mut collected = Vec::new();
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -348,7 +362,7 @@ async fn test_stream_logs_non_permission_error_returns_server_error() {
     let mut collected = Vec::new();
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -356,6 +370,91 @@ async fn test_stream_logs_non_permission_error_returns_server_error() {
 
     assert_eq!(exit_reason, StreamExitReason::ServerError);
     assert!(collected.is_empty());
+}
+
+// ========================================================================
+// Entry limits (--head N / --tail N)
+// ========================================================================
+
+/// Helper: run a one-shot (non-follow) stream and return the collected lines.
+async fn run_one_shot(mock: &MockClient, limit: usize, tail: bool, max_total: Option<usize>) -> Vec<String> {
+    let config_path = PathBuf::from("/fake/config.yaml");
+    let mut collected = Vec::new();
+    stream_logs(
+        mock,
+        StreamParams {
+            config_path: &config_path, services: &[], no_hooks: false,
+            mode: StreamMode::All, limit, filter: None, sql: false,
+            raw: false, tail, max_total,
+        },
+        never_shutdown(), never_quiescent(), None,
+        |st, entries| collect_batch(&mut collected, st, entries),
+    ).await.unwrap();
+    collected
+}
+
+/// `--head N` stops at N entries even when the server reports more data.
+/// Regression: `limit` used to be a per-batch size only, so the loop drained
+/// the whole log in batches of N.
+#[tokio::test(start_paused = true)]
+async fn test_head_stops_at_max_total() {
+    let mock = MockClient::new();
+    mock.push_response(stream_response(&[("svc", "line-1"), ("svc", "line-2")], true));
+    mock.push_response(stream_response(&[("svc", "line-3"), ("svc", "line-4")], true));
+    mock.push_response(stream_response(&[("svc", "line-5")], false));
+
+    let collected = run_one_shot(&mock, 3, false, Some(3)).await;
+
+    assert_eq!(collected, vec!["line-1", "line-2", "line-3"]);
+    // Stopped after the second request — never asked for the third batch.
+    assert_eq!(mock.calls().len(), 2);
+}
+
+/// A batch larger than what is still owed is truncated, not overshot.
+#[tokio::test(start_paused = true)]
+async fn test_head_truncates_oversized_batch() {
+    let mock = MockClient::new();
+    mock.push_response(stream_response(&[("svc", "line-1"), ("svc", "line-2"), ("svc", "line-3")], true));
+
+    let collected = run_one_shot(&mock, 2, false, Some(2)).await;
+
+    assert_eq!(collected, vec!["line-1", "line-2"]);
+    assert_eq!(mock.calls().len(), 1);
+}
+
+/// Bare `kepler logs` has no total and must still drain every batch.
+#[tokio::test(start_paused = true)]
+async fn test_no_max_total_drains_all_batches() {
+    let mock = MockClient::new();
+    mock.push_response(stream_response(&[("svc", "line-1"), ("svc", "line-2")], true));
+    mock.push_response(stream_response(&[("svc", "line-3"), ("svc", "line-4")], true));
+    mock.push_response(stream_response(&[("svc", "line-5")], false));
+
+    let collected = run_one_shot(&mock, 2, false, None).await;
+
+    assert_eq!(collected.len(), 5);
+}
+
+/// `--tail N` asks for the window once, then pages forward with the cursor.
+/// Regression: every request used to set `tail`, and the server's tail query
+/// ignores `after_id`, so a re-request replayed the same window.
+#[tokio::test(start_paused = true)]
+async fn test_tail_requests_window_once_then_pages_forward() {
+    let mock = MockClient::new();
+    mock.push_response(stream_response_with_last_id(&[("svc", "line-1"), ("svc", "line-2")], true, 42));
+    mock.push_response(stream_response_with_last_id(&[("svc", "line-3"), ("svc", "line-4")], true, 44));
+
+    let collected = run_one_shot(&mock, 4, true, Some(4)).await;
+
+    assert_eq!(collected, vec!["line-1", "line-2", "line-3", "line-4"]);
+
+    let calls = mock.calls();
+    assert_eq!(calls.len(), 2);
+    // First request resolves the window: no cursor, tail set, full count.
+    assert_eq!(calls[0], (None, 4, true));
+    // Second request is an ordinary forward read from the cursor, asking only
+    // for what is still owed.
+    assert_eq!(calls[1], (Some(42), 2, false));
 }
 
 // ========================================================================
@@ -373,7 +472,7 @@ async fn test_follow_empty_exits_on_quiescence() {
     let mut collected = Vec::new();
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
         async {},  // quiescence fires immediately
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -394,7 +493,7 @@ async fn test_follow_shutdown_returns_immediately() {
     let mut collected = Vec::new();
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false }, async {},
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, async {},
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -628,7 +727,7 @@ async fn test_follow_config_not_loaded_retries_then_starts() {
     let (tx, rx) = oneshot::channel::<()>();
     let mut tx = Some(tx);
     stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
         async { let _ = rx.await; },
         None,
         |st, entries| {
@@ -653,7 +752,7 @@ async fn test_follow_config_not_loaded_exits_on_quiescence() {
     let mut collected = Vec::new();
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
         async {},  // quiescence fires immediately (config was unloaded)
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -673,7 +772,7 @@ async fn test_follow_config_not_loaded_shutdown() {
     let mut collected = Vec::new();
 
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false }, async {},  // shutdown fires immediately
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, async {},  // shutdown fires immediately
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -694,7 +793,7 @@ async fn test_follow_shutdown_handles_starting_services() {
 
     // Shutdown resolves immediately — biased select picks it up before any read
     let exit_reason = stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false }, async {},
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, async {},
         never_quiescent(),
         None,
         |st, entries| collect_batch(&mut collected, st, entries),
@@ -717,7 +816,7 @@ async fn test_follow_exits_on_quiescence() {
     let (tx, rx) = oneshot::channel::<()>();
     let mut tx = Some(tx);
     stream_logs(
-        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false }, never_shutdown(),
+        &mock, StreamParams { config_path: &config_path, services: &[], no_hooks: false, mode: StreamMode::UntilQuiescent, limit: kepler_protocol::protocol::MAX_STREAM_BATCH_SIZE, filter: None, sql: false, raw: false, tail: false, max_total: None }, never_shutdown(),
         async { let _ = rx.await; },
         None,
         |st, entries| {

--- a/kepler-daemon/src/logs/log_reader.rs
+++ b/kepler-daemon/src/logs/log_reader.rs
@@ -85,6 +85,76 @@ impl LogReader {
         query_log_lines(&conn, &sql, &bind, Some(count as i64)).unwrap_or_default()
     }
 
+    /// Resolve the first ID of the "last `count` entries" window.
+    ///
+    /// Returns the ID of the `count`-th entry counted back from the newest, or
+    /// `None` when fewer than `count` entries match (the window starts at the
+    /// beginning of the log). Callers page forward from this ID with [`after`],
+    /// which keeps `--tail N` chunked instead of materializing N rows at once.
+    ///
+    /// The `OFFSET` still walks `count` entries of the rowid B-tree — it is
+    /// O(count), not a seek — but decodes a single row rather than all of them
+    /// (~14x faster than the equivalent `tail()` at 100k, and no large frame).
+    /// A keyset cursor can't replace it: this *is* the anchor a cursor needs,
+    /// and IDs are not dense enough (retention pruning, filters) to compute it
+    /// arithmetically from `max_id`.
+    pub fn tail_start_id(
+        &self,
+        count: usize,
+        services: &[String],
+        no_hooks: bool,
+        filter: Option<&SqlFragment>,
+        after_ts: Option<i64>,
+        before_ts: Option<i64>,
+    ) -> Result<Option<i64>, String> {
+        if count == 0 {
+            return Ok(None);
+        }
+
+        // Validate raw SQL filters before doing any I/O (DSL-generated ones are safe)
+        if let Some(frag) = filter {
+            if frag.params.is_empty() {
+                filter::validate_filter(&frag.sql)?;
+            }
+        }
+
+        let conn = match open_readonly(&self.db_path) {
+            Ok(c) => c,
+            Err(_) => return Ok(None),
+        };
+
+        if filter.is_some() {
+            filter::apply_filter_safeguards(&conn, filter::FILTER_QUERY_TIMEOUT, &["logs"]);
+        }
+
+        let (where_clause, mut bind) = build_filter(services, no_hooks, filter, after_ts, before_ts);
+        let sql = format!(
+            "SELECT id FROM logs {where_clause} ORDER BY id DESC LIMIT 1 OFFSET ?{next}",
+            where_clause = where_clause,
+            next = bind.len() + 1,
+        );
+        bind.push(BindValue::Int((count - 1) as i64));
+
+        let params_vec: Vec<Box<dyn rusqlite::types::ToSql>> = bind
+            .iter()
+            .map(|v| -> Box<dyn rusqlite::types::ToSql> {
+                match v {
+                    BindValue::Text(s) => Box::new(s.clone()),
+                    BindValue::Int(i) => Box::new(*i),
+                    BindValue::Real(f) => Box::new(*f),
+                }
+            })
+            .collect();
+        let params_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params_vec.iter().map(|p| p.as_ref()).collect();
+
+        // Query errors (e.g. missing table during a startup race) mean "no window",
+        // matching the other readers — only filter validation errors propagate.
+        Ok(conn
+            .query_row(&sql, params_refs.as_slice(), |row| row.get::<_, i64>(0))
+            .ok())
+    }
+
     /// Position-based pagination: get entries after `after_id`.
     /// Returns `(entries, has_more)`.
     ///

--- a/kepler-daemon/src/logs/mod.rs
+++ b/kepler-daemon/src/logs/mod.rs
@@ -26,6 +26,9 @@ pub fn log_query_dsl() -> QueryDsl {
         .field(Field::text("message").alias("line").fts())
         .field(Field::text("hook"))
         .field(Field::int("timestamp"))
+        // Row ID — unique and monotonic, the cursor for keyset pagination
+        // (`@id:>1234`). Exposed in `logs --json` output as `id`.
+        .field(Field::int("id"))
         .attributes("attributes")
         .build()
 }

--- a/kepler-daemon/src/main.rs
+++ b/kepler-daemon/src/main.rs
@@ -1345,21 +1345,33 @@ async fn handle_request(
 
             let reader = SqliteLogReader::new(db_path, storage_mode);
 
-            let (entries, has_more, last_id) = if tail {
-                // Tail mode: return last `limit` entries in chronological order
-                let entries = reader.tail(limit, &services, no_hooks, filter.as_ref(), after_ts, before_ts);
-                let last_id = entries.last().map(|e| e.id).unwrap_or(0);
-                (entries, has_pending, last_id)
-            } else {
-                // Determine the starting position
-                let effective_after_id = match after_id {
-                    Some(id) => id,
-                    None if from_end => reader.max_id(),
-                    None => 0,
+            // Never serialize more than one chunk into a single response — the
+            // client pages forward via `after_id` for the rest. Without this, a
+            // large `limit` (e.g. `--tail 100000`) would build one huge frame.
+            let chunk = limit.min(kepler_protocol::protocol::STREAM_CHUNK_SIZE);
+
+            let (entries, has_more, last_id) = {
+                // Tail mode: resolve the start of the "last `limit` entries"
+                // window, then read forward from it like any other cursor read.
+                // The client caps the total at `limit`.
+                let effective_after_id = if tail {
+                    match reader.tail_start_id(limit, &services, no_hooks, filter.as_ref(), after_ts, before_ts) {
+                        // `- 1` because `after` is exclusive and the window is inclusive
+                        Ok(Some(start_id)) => start_id - 1,
+                        // Fewer matches than requested — the window is the whole log
+                        Ok(None) => 0,
+                        Err(e) => return Response::error(format!("invalid filter: {}", e)),
+                    }
+                } else {
+                    match after_id {
+                        Some(id) => id,
+                        None if from_end => reader.max_id(),
+                        None => 0,
+                    }
                 };
 
                 // Read entries
-                let (entries, has_more) = match reader.after(effective_after_id, limit, &services, no_hooks, filter.as_ref(), after_ts, before_ts) {
+                let (entries, has_more) = match reader.after(effective_after_id, chunk, &services, no_hooks, filter.as_ref(), after_ts, before_ts) {
                     Ok(r) => r,
                     Err(e) => return Response::error(format!("invalid filter: {}", e)),
                 };

--- a/kepler-e2e/config/attached_start_test/test_restart_follow_no_replay.kepler.yaml
+++ b/kepler-e2e/config/attached_start_test/test_restart_follow_no_replay.kepler.yaml
@@ -1,0 +1,3 @@
+services:
+  looper:
+    command: ["sh", "-c", "echo RESTART_MARKER; sleep 300"]

--- a/kepler-e2e/config/attached_start_test/test_start_no_replay.kepler.yaml
+++ b/kepler-e2e/config/attached_start_test/test_start_no_replay.kepler.yaml
@@ -1,0 +1,3 @@
+services:
+  once:
+    command: ["sh", "-c", "echo START_MARKER; exit 0"]

--- a/kepler-e2e/config/logs_test/test_logs_entry_limits.kepler.yaml
+++ b/kepler-e2e/config/logs_test/test_logs_entry_limits.kepler.yaml
@@ -1,0 +1,3 @@
+services:
+  bulk-logger:
+    command: ["sh", "-c", "i=1; while [ $i -le 6000 ]; do printf 'LINE_%05d\\n' $i; i=$((i+1)); done; echo BULK_DONE; sleep 300"]

--- a/kepler-e2e/config/start_behavior_test/test_foreground_start_shows_output.kepler.yaml
+++ b/kepler-e2e/config/start_behavior_test/test_foreground_start_shows_output.kepler.yaml
@@ -1,4 +1,6 @@
 services:
   oneshot:
-    command: ["sh", "-c", "echo FOREGROUND_MARKER; exit 0"]
+    # Unique token per run, so a replayed line from an earlier run is
+    # distinguishable from this run's output.
+    command: ["sh", "-c", "echo FOREGROUND_MARKER_$(date +%s%N); exit 0"]
     restart: "no"

--- a/kepler-e2e/tests/attached_start_test.rs
+++ b/kepler-e2e/tests/attached_start_test.rs
@@ -195,3 +195,77 @@ async fn test_restart_follow_blocks() -> E2eResult<()> {
 
     Ok(())
 }
+
+/// Attached `kepler start` must stream only the current run's logs.
+///
+/// Regression: the stream started at entry ID 0, so every previous run stored
+/// in the log database was replayed before the new output.
+#[tokio::test]
+async fn test_attached_start_does_not_replay_previous_run() -> E2eResult<()> {
+    let mut harness = E2eHarness::new().await?;
+    let config_path = harness.load_config(TEST_MODULE, "test_start_no_replay")?;
+    let config_str = config_path.to_str().unwrap().to_string();
+
+    harness.start_daemon().await?;
+
+    // Run 1: the service prints once and exits, so the attached start returns
+    // when quiescence is reached.
+    let run1 = harness
+        .run_cli_with_timeout(&["-f", &config_str, "start"], Duration::from_secs(20))
+        .await?;
+    assert_eq!(
+        run1.stdout.matches("START_MARKER").count(),
+        1,
+        "run 1 should print the marker once. stdout: {}",
+        run1.stdout
+    );
+
+    // Run 2: the service is restarted and prints again — run 1's entry is still
+    // in the log database but must not be streamed.
+    let run2 = harness
+        .run_cli_with_timeout(&["-f", &config_str, "start"], Duration::from_secs(20))
+        .await?;
+    assert_eq!(
+        run2.stdout.matches("START_MARKER").count(),
+        1,
+        "run 2 should print only the new line, not replay run 1. stdout: {}",
+        run2.stdout
+    );
+
+    harness.stop_daemon().await?;
+    Ok(())
+}
+
+/// `kepler restart --follow` must stream only the restarted run's logs.
+#[tokio::test]
+async fn test_restart_follow_does_not_replay_previous_run() -> E2eResult<()> {
+    let mut harness = E2eHarness::new().await?;
+    let config_path = harness.load_config(TEST_MODULE, "test_restart_follow_no_replay")?;
+    let config_str = config_path.to_str().unwrap().to_string();
+
+    harness.start_daemon().await?;
+
+    // First run writes one marker.
+    harness.start_services(&config_path).await?.assert_success();
+    harness
+        .wait_for_log_content(&config_path, "RESTART_MARKER", Duration::from_secs(10))
+        .await?;
+
+    // `restart --follow` streams until interrupted — run it in the background,
+    // give the restarted service time to log, then stop it and read the output.
+    let mut child = harness.spawn_cli_background(&["-f", &config_str, "restart", "--follow"])?;
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    let _ = child.kill();
+    let output = child.wait_with_output()?;
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+
+    assert_eq!(
+        stdout.matches("RESTART_MARKER").count(),
+        1,
+        "restart --follow should print only the restarted run's line. stdout: {}",
+        stdout
+    );
+
+    harness.stop_daemon().await?;
+    Ok(())
+}

--- a/kepler-e2e/tests/logs_test.rs
+++ b/kepler-e2e/tests/logs_test.rs
@@ -674,3 +674,94 @@ async fn test_logs_dsl_filter() -> E2eResult<()> {
 
     Ok(())
 }
+
+/// `--head N` / `--tail N` must return exactly N entries, and `@id` must work
+/// as a pagination cursor across pages.
+///
+/// Regression: `--head N` used to treat N as a per-request batch size and kept
+/// paging until the whole log was printed.
+#[tokio::test]
+async fn test_logs_entry_limits_and_pagination() -> E2eResult<()> {
+    let mut harness = E2eHarness::new().await?;
+    let config_path = harness.load_config(TEST_MODULE, "test_logs_entry_limits")?;
+    let config_str = config_path.to_str().unwrap().to_string();
+
+    harness.start_daemon().await?;
+    harness.start_services(&config_path).await?.assert_success();
+    harness
+        .wait_for_service_status(&config_path, "bulk-logger", "running", Duration::from_secs(10))
+        .await?;
+    // All 200 lines are written before this marker.
+    harness
+        .wait_for_log_content(&config_path, "BULK_DONE", Duration::from_secs(10))
+        .await?;
+
+    // Raw mode: one log entry per output line, so counting is exact.
+    // The service writes LINE_00001..LINE_06000 followed by BULK_DONE — 6001 entries.
+    let raw_lines = |out: &str| -> Vec<String> {
+        out.lines().filter(|l| !l.trim().is_empty()).map(|s| s.to_string()).collect()
+    };
+
+    // --head N returns the FIRST N entries, and only N.
+    let head = harness
+        .run_cli(&["-f", &config_str, "logs", "--head", "10", "--raw"])
+        .await?;
+    head.assert_success();
+    let head_lines = raw_lines(&head.stdout);
+    assert_eq!(head_lines.len(), 10, "--head 10 should print 10 entries, got: {}", head.stdout);
+    assert_eq!(head_lines[0], "LINE_00001");
+    assert_eq!(head_lines[9], "LINE_00010");
+
+    // --tail N returns the LAST N entries, chronologically, and only N.
+    let tail = harness
+        .run_cli(&["-f", &config_str, "logs", "--tail", "10", "--raw"])
+        .await?;
+    tail.assert_success();
+    let tail_lines = raw_lines(&tail.stdout);
+    assert_eq!(tail_lines.len(), 10, "--tail 10 should print 10 entries, got: {}", tail.stdout);
+    assert_eq!(tail_lines[0], "LINE_05992");
+    assert_eq!(tail_lines[9], "BULK_DONE");
+
+    // A count larger than STREAM_CHUNK_SIZE (5000) still returns exactly N, in
+    // order: the daemon splits it across responses and the client pages through.
+    let big = harness
+        .run_cli(&["-f", &config_str, "logs", "--tail", "5500", "--raw"])
+        .await?;
+    big.assert_success();
+    let big_lines = raw_lines(&big.stdout);
+    assert_eq!(big_lines.len(), 5500, "--tail 5500 should print 5500 entries");
+    assert_eq!(big_lines[0], "LINE_00502");
+    assert_eq!(big_lines[5499], "BULK_DONE");
+
+    // Forward pagination with the @id cursor from --json output.
+    let json_ids = |out: &str| -> Vec<i64> {
+        out.lines()
+            .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+            .filter_map(|v| v.get("id").and_then(|i| i.as_i64()))
+            .collect()
+    };
+
+    let page1 = harness
+        .run_cli(&["-f", &config_str, "logs", "--head", "5", "--json"])
+        .await?;
+    page1.assert_success();
+    let ids1 = json_ids(&page1.stdout);
+    assert_eq!(ids1.len(), 5, "page 1 should have 5 entries. stdout: {}", page1.stdout);
+
+    let cursor = ids1.last().copied().unwrap();
+    let cursor_filter = format!("@id:>{}", cursor);
+    let page2 = harness
+        .run_cli(&["-f", &config_str, "logs", "--head", "5", "-F", &cursor_filter, "--json"])
+        .await?;
+    page2.assert_success();
+    let ids2 = json_ids(&page2.stdout);
+    assert_eq!(ids2.len(), 5, "page 2 should have 5 entries. stdout: {}", page2.stdout);
+    assert!(
+        ids2.iter().all(|id| *id > cursor),
+        "page 2 must start after the cursor: {:?} vs {}",
+        ids2, cursor
+    );
+
+    harness.stop_daemon().await?;
+    Ok(())
+}

--- a/kepler-e2e/tests/start_behavior_test.rs
+++ b/kepler-e2e/tests/start_behavior_test.rs
@@ -526,9 +526,14 @@ async fn test_start_specific_restarts_exited_service() -> E2eResult<()> {
 
 /// `kepler start` (foreground/attached mode) on a oneshot service must display
 /// the current run's log output. Reproduces the bug where the second foreground
-/// start showed only historical logs and missed the new run's output because
-/// the CLI received a premature Quiescent signal (from the subscription recheck)
-/// before the Start request was processed by the daemon.
+/// start missed the new run's output because the CLI received a premature
+/// Quiescent signal (from the subscription recheck) before the Start request was
+/// processed by the daemon.
+///
+/// Each run emits a unique token, so "showed the current run" is asserted
+/// directly rather than by counting accumulated lines. Attached start streams
+/// only the current run — earlier runs stay in the log database but are not
+/// replayed — so a missed run now shows up as zero markers.
 #[tokio::test]
 async fn test_foreground_start_shows_current_run_output() -> E2eResult<()> {
     let mut harness = E2eHarness::new().await?;
@@ -537,57 +542,47 @@ async fn test_foreground_start_shows_current_run_output() -> E2eResult<()> {
 
     harness.start_daemon().await?;
 
-    // First foreground start — oneshot runs and exits, CLI should show the marker
-    let output = harness
-        .run_cli_with_timeout(
-            &["-f", config_str, "start"],
-            Duration::from_secs(10),
-        )
-        .await?;
-    output.assert_success();
-    let count_1 = count_marker(&output.stdout, "FOREGROUND_MARKER");
-    assert_eq!(
-        count_1, 1,
-        "First foreground start should show 1 log line. stdout:\n{}",
-        output.stdout
-    );
+    let marker_tokens = |stdout: &str| -> Vec<String> {
+        stdout
+            .split_whitespace()
+            .filter(|w| w.starts_with("FOREGROUND_MARKER_"))
+            .map(|w| w.to_string())
+            .collect()
+    };
 
-    // Wait for service to fully settle
-    harness
-        .wait_for_service_status(&config_path, "oneshot", "exited", Duration::from_secs(5))
-        .await?;
+    let mut seen: Vec<String> = Vec::new();
 
-    // Second foreground start — must show the NEW run's output (2 lines total:
-    // 1 from first run + 1 from this run). The bug showed only 1 line (old).
-    let output = harness
-        .run_cli_with_timeout(
-            &["-f", config_str, "start"],
-            Duration::from_secs(10),
-        )
-        .await?;
-    output.assert_success();
-    let count_2 = count_marker(&output.stdout, "FOREGROUND_MARKER");
-    assert_eq!(
-        count_2, 2,
-        "Second foreground start should show 2 log lines (old + new). \
-         Got {} — if 1, the current run's output was missed. stdout:\n{}",
-        count_2, output.stdout
-    );
+    for run in 1..=3 {
+        let output = harness
+            .run_cli_with_timeout(&["-f", config_str, "start"], Duration::from_secs(10))
+            .await?;
+        output.assert_success();
 
-    // Third foreground start — same pattern, 3 lines total
-    let output = harness
-        .run_cli_with_timeout(
-            &["-f", config_str, "start"],
-            Duration::from_secs(10),
-        )
-        .await?;
-    output.assert_success();
-    let count_3 = count_marker(&output.stdout, "FOREGROUND_MARKER");
-    assert_eq!(
-        count_3, 3,
-        "Third foreground start should show 3 log lines. Got {}. stdout:\n{}",
-        count_3, output.stdout
-    );
+        let tokens = marker_tokens(&output.stdout);
+        assert_eq!(
+            tokens.len(),
+            1,
+            "Foreground start #{} should show exactly this run's line. \
+             Got {} — 0 means the current run's output was missed, >1 means \
+             earlier runs were replayed. stdout:\n{}",
+            run,
+            tokens.len(),
+            output.stdout
+        );
+        assert!(
+            !seen.contains(&tokens[0]),
+            "Foreground start #{} replayed a previous run's line ({}). stdout:\n{}",
+            run,
+            tokens[0],
+            output.stdout
+        );
+        seen.push(tokens[0].clone());
+
+        // Wait for the service to fully settle before the next start
+        harness
+            .wait_for_service_status(&config_path, "oneshot", "exited", Duration::from_secs(5))
+            .await?;
+    }
 
     harness.stop_daemon().await?;
     Ok(())

--- a/kepler-protocol/src/protocol.rs
+++ b/kepler-protocol/src/protocol.rs
@@ -14,6 +14,14 @@ pub const MAX_LINES_ONE_SHOT: usize = 10_000;
 /// Maximum entries per stream batch (secondary cap; byte budget is the primary limit)
 pub const MAX_STREAM_BATCH_SIZE: usize = 50_000;
 
+/// Maximum entries the daemon puts in a single `LogStream` response.
+///
+/// Responses are not size-capped (see `encode_server_message`), so an
+/// unclamped `limit` would serialize the whole result set into one frame.
+/// The client keeps paginating via `after_id` while `has_more` is set, so
+/// this only controls how much is in flight at once.
+pub const STREAM_CHUNK_SIZE: usize = 5_000;
+
 fn default_stream_limit() -> usize { MAX_STREAM_BATCH_SIZE }
 
 /// Request sent from CLI to daemon

--- a/kepler-tests/tests/query_dsl_tests.rs
+++ b/kepler-tests/tests/query_dsl_tests.rs
@@ -422,6 +422,132 @@ fn dsl_syntax_error() {
 }
 
 // ============================================================================
+// Row ID (pagination cursor) tests
+// ============================================================================
+
+/// Query logs using a DSL filter and return the row IDs of matching entries.
+fn query_ids(reader: &SqliteLogReader, dsl: &str, limit: usize) -> Vec<i64> {
+    let frag = log_query_dsl().parse(dsl, 0).expect("DSL parse failed");
+    let (entries, _) = reader
+        .after(0, limit, &[], false, Some(&frag), None, None)
+        .expect("query failed");
+    entries.into_iter().map(|e| e.id).collect()
+}
+
+#[test]
+fn dsl_id_filters_on_row_id() {
+    let temp = TempDir::new().unwrap();
+    let (store, reader) = setup_log_store(temp.path());
+
+    for i in 0..5 {
+        write_log(&store, "web", &format!("line {}", i), "info");
+    }
+
+    let all = query_ids(&reader, "@service:web", 100);
+    assert_eq!(all.len(), 5);
+
+    // `@id` resolves to the logs.id column, not the JSON attributes fallback.
+    let after_second = query_ids(&reader, &format!("@id:>{}", all[1]), 100);
+    assert_eq!(after_second, all[2..].to_vec());
+}
+
+#[test]
+fn dsl_id_cursor_paginates_without_gaps_or_overlap() {
+    let temp = TempDir::new().unwrap();
+    let (store, reader) = setup_log_store(temp.path());
+
+    for i in 0..7 {
+        let level = if i % 2 == 0 { "error" } else { "info" };
+        write_log(&store, "web", &format!("line {}", i), level);
+    }
+
+    let expected = query_ids(&reader, "@level:error", 100);
+    assert_eq!(expected.len(), 4);
+
+    // Walk forward in pages of 2 using the last ID of each page as the cursor.
+    let mut seen = Vec::new();
+    let mut cursor: Option<i64> = None;
+    loop {
+        let query = match cursor {
+            Some(id) => format!("@level:error AND @id:>{}", id),
+            None => "@level:error".to_string(),
+        };
+        let page = query_ids(&reader, &query, 2);
+        if page.is_empty() {
+            break;
+        }
+        assert!(page.len() <= 2);
+        cursor = page.last().copied();
+        seen.extend(page);
+    }
+
+    assert_eq!(seen, expected);
+}
+
+// ============================================================================
+// Tail window resolution (`--tail N`)
+// ============================================================================
+
+#[test]
+fn tail_start_id_resolves_window_and_pages_forward() {
+    let temp = TempDir::new().unwrap();
+    let (store, reader) = setup_log_store(temp.path());
+
+    // 9 matching lines interleaved with non-matching ones.
+    for i in 0..9 {
+        write_log(&store, "web", &format!("err {}", i), "error");
+        write_log(&store, "web", &format!("noise {}", i), "info");
+    }
+
+    let frag = log_query_dsl().parse("@level:error", 0).unwrap();
+    let all = query_ids(&reader, "@level:error", 100);
+    assert_eq!(all.len(), 9);
+
+    // `--tail 4`: the window starts at the 4th entry counted from the newest.
+    let start = reader
+        .tail_start_id(4, &[], false, Some(&frag), None, None)
+        .unwrap()
+        .expect("window start");
+    assert_eq!(start, all[5]);
+
+    // Reading forward from it yields exactly the last 4, chronologically —
+    // the filter is applied before the window, so noise never takes a slot.
+    let (entries, _) = reader
+        .after(start - 1, 4, &[], false, Some(&frag), None, None)
+        .unwrap();
+    assert_eq!(entries.iter().map(|e| e.id).collect::<Vec<_>>(), all[5..].to_vec());
+
+    // Chunked reads from the same start reassemble into the same window.
+    let (first, has_more) = reader.after(start - 1, 2, &[], false, Some(&frag), None, None).unwrap();
+    assert!(has_more);
+    let cursor = first.last().unwrap().id;
+    let (second, _) = reader.after(cursor, 2, &[], false, Some(&frag), None, None).unwrap();
+    let chunked: Vec<i64> = first.iter().chain(second.iter()).map(|e| e.id).collect();
+    assert_eq!(chunked, all[5..].to_vec());
+}
+
+#[test]
+fn tail_start_id_saturates_when_fewer_matches_than_requested() {
+    let temp = TempDir::new().unwrap();
+    let (store, reader) = setup_log_store(temp.path());
+
+    write_log(&store, "web", "err 0", "error");
+    write_log(&store, "web", "err 1", "error");
+
+    let frag = log_query_dsl().parse("@level:error", 0).unwrap();
+    // Asking for more than exists means "start at the beginning".
+    assert_eq!(
+        reader.tail_start_id(100, &[], false, Some(&frag), None, None).unwrap(),
+        None
+    );
+    // A zero count has no window.
+    assert_eq!(
+        reader.tail_start_id(0, &[], false, Some(&frag), None, None).unwrap(),
+        None
+    );
+}
+
+// ============================================================================
 // DSL → SQL authorizer safety test
 // ============================================================================
 


### PR DESCRIPTION
## What does this PR do ?

Fixes log pagination and log streaming on start, and adds the pieces needed to paginate logs from the CLI at all.

**`--head N` now limits.** It was a per-request *batch size*, not a total: the stream loop kept paging while the daemon reported `has_more`, so `kepler logs --head 10` printed the entire log in batches of 10. `--head`/`--tail` now bound the total entries printed. Bare `kepler logs` is unchanged and still drains.

**`--tail N` now streams instead of arriving in one shot.** It used to run a single `ORDER BY id DESC LIMIT N` and serialize the whole result into one response frame — server responses have no size cap, so `--tail 100000` built one enormous frame. The daemon now resolves the start of the "last N" window (`LogReader::tail_start_id`, a single `LIMIT 1 OFFSET N-1` returning one id) and reads forward from it through the same cursor path as `--head`, capped at `STREAM_CHUNK_SIZE` (5,000) entries per response. Only the first request carries the `tail` flag; the rest page forward. This also applies to the default path, which previously sent up to 50k rows per frame.

**`id` is exposed as a pagination cursor.** `kepler logs --json` now emits `id` on every line, and `@id` is a first-class DSL field, so pages can be walked without needing the `logs:search:sql` right:

```bash
kepler logs --head 50 -F '@level:error' --json                  # cursor = id of last line
kepler logs --head 50 -F '@level:error AND @id:>41230' --json    # next page
```

`@id` is unique and monotonic; `@timestamp` (also now documented) can repeat within a millisecond and loses rows at page boundaries.

**Attached `start` and `restart --follow` no longer replay previous runs.** Both streamed from entry ID 0 — `StreamMode::Follow`, the only variant setting `from_end`, is never constructed — so every run stored in the log database was reprinted before the new output. Both paths now capture the log's current end *before* the launch request and anchor the stream there. Capturing it before launching is the point: anchoring once streaming has started races with startup output and drops the lines that matter most. If the position can't be determined (no logs yet, config not loaded, permission denied) it falls back to previous behaviour. `kepler logs --follow` is deliberately unchanged — showing existing logs then following is its documented behaviour.

**One-shot reads wait for pending flushes.** The old `--tail` re-issued its query while `has_pending` was set, which incidentally spun until buffered rows landed. Paging forward removed that, so an empty batch (rows written but still in the writer actor) ended the stream and dropped them. `StreamMode::All` now polls every 25ms for up to ~2s when the server reports more data but returns none, resetting on progress and staying responsive to Ctrl+C. Follow modes don't need it — they get a `LogsAvailable` event.

Behaviour changes to `--head`, `--tail`, and attached start are why this is a minor bump to **0.16.0**.

## Other changes ?

- No protocol fields changed, so daemon/CLI stay compatible in both directions: an old CLI against a new daemon just sees smaller batches and keeps looping; a new CLI against an old daemon gets everything at once and caps client-side.
- Docs updated: `log-management.md` (`@id`/`@timestamp` fields, pagination example, head/tail semantics), `cli-reference.md`, `architecture.md` (cursor/chunking design).
- `test_foreground_start_shows_current_run_output` asserted the *old* replay behaviour — it counted accumulated lines (run 2 ⇒ 2 lines) as a proxy for "the current run wasn't missed". Rewritten so each run emits a unique token and asserts exactly one unseen marker: a missed run is now 0 markers, a replay is >1, both distinguishable.
- `examples/complex.kepler.yaml` switches log retention to `retain` — unrelated to the fixes, carried in from the working tree.
- Not addressed: `MAX_LINES_ONE_SHOT` and `LogReader::tail_bounded()` are dead code (both already unused before this PR).

## How to Test ?

Tests must run through Docker per `docs/testing.md`:

```bash
docker compose run --rm test cargo test -p kepler-cli -p kepler-daemon -p kepler-protocol -p kepler-tests
docker compose run --rm test cargo test -p kepler-e2e
```

Full e2e suite: **316 passed, 0 failed.**

Key coverage added:

- `kepler-e2e/tests/logs_test.rs::test_logs_entry_limits_and_pagination` — 6,000-line fixture: `--head 10` gives exactly the first 10, `--tail 10` the last 10, `--tail 5500` spans multiple chunks and returns exactly 5,500 in order, and `--head 5 -F '@id:>cursor' --json` pages forward without overlap.
- `kepler-e2e/tests/attached_start_test.rs` — two no-replay regression tests for attached start and `restart --follow`.
- `kepler-tests/tests/query_dsl_tests.rs` — `@id` resolves to the column (not the JSON-attribute fallback), cursor paging with no gaps/overlap, `tail_start_id` window resolution and saturation.
- `kepler-cli/src/tests.rs` — stream-loop unit tests: head stops at N without issuing an extra request, oversized batches truncate, no-total still drains, tail sets the flag once then pages with the right cursor and remainder, anchor reaches the first request.

Manual check, on a config that has run before:

```bash
kepler -f config.yaml start        # run once, note the output
kepler -f config.yaml start        # must show only this run, not the previous one
kepler -f config.yaml logs --head 10 --raw | wc -l   # exactly 10
kepler -f config.yaml logs --tail 10 --raw | wc -l   # exactly 10
```
