### PR TITLE
Fix flakky tests caused by spawn_service race condition

### DIFF
--- a/kepler-daemon/src/orchestrator/mod.rs
+++ b/kepler-daemon/src/orchestrator/mod.rs
@@ -2809,7 +2809,8 @@ impl ServiceOrchestrator {
             config_hash: handle.config_hash().to_string(),
         };
 
-        let process_handle = match spawn_service(spawn_params).await {
+        let gate_t0 = std::time::Instant::now(); // TEMP measurement
+        let (process_handle, spawn_gate) = match spawn_service(spawn_params).await {
             Ok(ph) => ph,
             Err(e) => {
                 // Spawn failed — clean up the cgroup created by prepare_spawn
@@ -2828,6 +2829,13 @@ impl ServiceOrchestrator {
         let _ = handle
             .set_service_status(service_name, ServiceStatus::Running)
             .await;
+
+        // Registration complete — a process that already exited may now be
+        // reported. Released last so `handle_exit` always sees the stored
+        // handle (for output capture tasks) and a status it can transition
+        // from. See `SpawnGate`.
+        info!("GATEDBG registration for {} took {:?}", service_name, gate_t0.elapsed());
+        spawn_gate.release();
 
         Ok(())
     }

--- a/kepler-daemon/src/process/mod.rs
+++ b/kepler-daemon/src/process/mod.rs
@@ -52,8 +52,50 @@ pub struct SpawnServiceParams<'a> {
     pub config_hash: String,
 }
 
-/// Spawn a service process with signal-based monitoring
-pub async fn spawn_service(params: SpawnServiceParams<'_>) -> Result<ProcessHandle> {
+/// How long the process monitor waits for [`SpawnGate`] before reporting an
+/// exit regardless.
+///
+/// This is a liveness backstop against a caller that never releases the gate,
+/// not a tuning knob: the two outcomes are asymmetric. Firing late costs a
+/// bounded delay in reporting an exit, and says so in the log. Firing early
+/// re-opens the race the gate exists to close, silently. So it is set well
+/// above any legitimate registration.
+///
+/// Measured over ~1960 registrations across four full e2e runs pinned to 2 CPUs:
+/// median 1.6ms, p99 5.3ms, max 9ms in warm runs. A single cold-start outlier
+/// of 16.8s (first run after a rebuild, never reproduced) is why this is not
+/// single-digit seconds.
+const SPAWN_GATE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Gate that holds back a service's exit event until the caller has finished
+/// registering the spawned process.
+///
+/// A short-lived process can exit before `spawn_service` even returns. Without
+/// this gate the exit event races the start path: `handle_exit` would look for
+/// output capture tasks before the `ProcessHandle` is stored (losing captured
+/// `::output::` values) and set the terminal status before the start path sets
+/// `Running` (leaving the service stuck in `Running` forever).
+///
+/// Dropping the gate releases the exit event — the start path always releases
+/// it, on success or failure, and a dropped gate never blocks the monitor.
+pub struct SpawnGate(oneshot::Sender<()>);
+
+impl SpawnGate {
+    /// Release the exit event. Dropping the gate does the same thing; calling
+    /// this makes the ordering requirement visible at the call site.
+    pub fn release(self) {
+        // Err just means the monitor is already gone (process reaped and task
+        // finished, or the service was stopped) — nothing to release.
+        let _ = self.0.send(());
+    }
+}
+
+/// Spawn a service process with signal-based monitoring.
+///
+/// Returns the process handle and a [`SpawnGate`]. The caller MUST store the
+/// handle and publish the running status before releasing (or dropping) the
+/// gate — see [`SpawnGate`].
+pub async fn spawn_service(params: SpawnServiceParams<'_>) -> Result<(ProcessHandle, SpawnGate)> {
     let SpawnServiceParams {
         service_name,
         spec,
@@ -115,6 +157,9 @@ pub async fn spawn_service(params: SpawnServiceParams<'_>) -> Result<ProcessHand
     // Create shutdown channel for graceful stop (round-trip: request → reply)
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<ShutdownRequest>();
 
+    // Gate the exit event on the caller finishing registration (see SpawnGate)
+    let (gate_tx, gate_rx) = oneshot::channel::<()>();
+
     // Spawn process monitor with the Child (signal-based monitoring)
     let config_path = handle.config_path().to_path_buf();
     let service_name_clone = service_name.to_string();
@@ -130,6 +175,7 @@ pub async fn spawn_service(params: SpawnServiceParams<'_>) -> Result<ProcessHand
             exit_tx,
             containment,
             config_hash,
+            gate_rx,
         )
         .await;
     });
@@ -145,7 +191,7 @@ pub async fn spawn_service(params: SpawnServiceParams<'_>) -> Result<ProcessHand
         debug!("FD count after spawning service {}: {}", service_name, fd_count);
     }
 
-    Ok(process_handle)
+    Ok((process_handle, SpawnGate(gate_tx)))
 }
 
 /// Monitor a process using signal-based waiting (child.wait())
@@ -160,6 +206,7 @@ async fn monitor_process(
     exit_tx: mpsc::Sender<ProcessExitEvent>,
     containment: ContainmentManager,
     config_hash: String,
+    spawn_gate: oneshot::Receiver<()>,
 ) {
     // Use tokio::select! to wait for either process exit or shutdown signal
     tokio::select! {
@@ -182,6 +229,22 @@ async fn monitor_process(
                 "Service {} exited with code {:?} signal {:?}",
                 service_name, exit_code, signal
             );
+
+            // Wait for the spawner to finish registering this process before the
+            // exit is announced. A process can exit before `spawn_service`
+            // returns; delivering the event first would race the start path.
+            // An Err means the gate was dropped (start path finished or failed),
+            // which is exactly the "go ahead" signal.
+            //
+            // Bounded: a caller that never releases the gate must not strand the
+            // service in a non-terminal status — the very bug this prevents.
+            // Reporting late is recoverable; never reporting is not.
+            if tokio::time::timeout(SPAWN_GATE_TIMEOUT, spawn_gate).await.is_err() {
+                warn!(
+                    "Spawn gate for {} not released within {:?}; reporting exit anyway",
+                    service_name, SPAWN_GATE_TIMEOUT
+                );
+            }
 
             // Send exit event with overflow handling
             let event = ProcessExitEvent {

--- a/kepler-e2e/config/service_lifecycle_test/test_instant_exit_status.kepler.yaml
+++ b/kepler-e2e/config/service_lifecycle_test/test_instant_exit_status.kepler.yaml
@@ -1,0 +1,6 @@
+services:
+  # Exits as fast as the kernel allows — typically before the spawner has
+  # finished registering the process, which is the race this config exercises.
+  instant:
+    command: ["true"]
+    restart: "no"

--- a/kepler-e2e/tests/service_lifecycle_test.rs
+++ b/kepler-e2e/tests/service_lifecycle_test.rs
@@ -232,3 +232,36 @@ async fn test_ps_shows_all_services() -> E2eResult<()> {
 
     Ok(())
 }
+
+/// A service that exits before the spawner finishes registering it must still
+/// reach a terminal status.
+///
+/// Regression: the process monitor could deliver the exit event while the start
+/// path was still running, so `handle_exit` set `Exited` and the start path then
+/// overwrote it with `Running` — the service stayed `Running` forever with no
+/// process behind it. Repeated because the window is timing-dependent.
+#[tokio::test]
+async fn test_instant_exit_reaches_terminal_status() -> E2eResult<()> {
+    for attempt in 1..=10 {
+        let mut harness = E2eHarness::new().await?;
+        let config_path = harness.load_config(TEST_MODULE, "test_instant_exit_status")?;
+
+        harness.start_daemon().await?;
+        harness.start_services(&config_path).await?.assert_success();
+
+        let result = harness
+            .wait_for_service_status(&config_path, "instant", "exited", Duration::from_secs(10))
+            .await;
+
+        harness.stop_daemon().await?;
+
+        if let Err(e) = result {
+            panic!(
+                "attempt {}: a service that exited immediately never reached 'exited' \
+                 (stuck in the status the start path published): {:?}",
+                attempt, e
+            );
+        }
+    }
+    Ok(())
+}

--- a/kepler-tests/src/helpers/daemon_harness.rs
+++ b/kepler-tests/src/helpers/daemon_harness.rs
@@ -497,7 +497,7 @@ impl TestDaemonHarness {
             containment: self.containment.clone(),
             config_hash: self.handle.config_hash().to_string(),
         };
-        let process_handle = spawn_service(spawn_params).await?;
+        let (process_handle, spawn_gate) = spawn_service(spawn_params).await?;
 
         // Store the handle
         self.handle
@@ -516,6 +516,9 @@ impl TestDaemonHarness {
             .handle
             .set_service_status(service_name, ServiceStatus::Running)
             .await;
+
+        // Registration done — allow the exit event through (see SpawnGate)
+        spawn_gate.release();
 
         // Run post_start hook
         run_service_hook(
@@ -1024,7 +1027,7 @@ impl TestDaemonHarness {
                     containment: containment.clone(),
                     config_hash: handle.config_hash().to_string(),
                 };
-                if let Ok(process_handle) = spawn_service(spawn_params).await {
+                if let Ok((process_handle, spawn_gate)) = spawn_service(spawn_params).await {
                     handle
                         .store_process_handle(&event.service_name, process_handle)
                         .await;
@@ -1039,6 +1042,8 @@ impl TestDaemonHarness {
                     let _ = handle
                         .set_service_status(&event.service_name, ServiceStatus::Running)
                         .await;
+                    // Registration done — allow the exit event through (see SpawnGate)
+                    spawn_gate.release();
                     // Note: PID is already set by spawn_service
                     let _ = handle.increment_restart_count(&event.service_name).await;
                 }
@@ -1244,7 +1249,7 @@ impl TestDaemonHarness {
                         containment: containment.clone(),
                         config_hash: handle.config_hash().to_string(),
                     };
-                    if let Ok(process_handle) = spawn_service(spawn_params).await {
+                    if let Ok((process_handle, spawn_gate)) = spawn_service(spawn_params).await {
                         handle
                             .store_process_handle(&event.service_name, process_handle)
                             .await;
@@ -1259,6 +1264,8 @@ impl TestDaemonHarness {
                         let _ = handle
                             .set_service_status(&event.service_name, ServiceStatus::Running)
                             .await;
+                        // Registration done — allow the exit event through (see SpawnGate)
+                        spawn_gate.release();
                         let _ = handle.increment_restart_count(&event.service_name).await;
                     }
                 } else {


### PR DESCRIPTION
## What does this PR do ?

Fixes a race condition where a service that exits before `spawn_service` returns could get stuck in the `Running` state permanently. The process monitor could deliver the exit event while the start path was still registering the process, causing `handle_exit` to set `Exited` and then the start path to overwrite it with `Running`, leaving the service in `Running` forever with no process behind it.

The fix introduces a `SpawnGate`  a oneshot channel wrapper returned alongside the `ProcessHandle` from `spawn_service`. The process monitor waits on the gate before announcing the exit event, ensuring the `ProcessHandle` is stored and the `Running` status is published before `handle_exit` can act on the exit. The gate is released (or dropped) by the caller after registration is complete, on both success and failure paths.

## Other changes ?

Added an e2e test config (`test_instant_exit_status.kepler.yaml`) that runs `true` as a service — a command that exits as fast as the kernel allows, reliably triggering the race window. The accompanying regression test (`test_instant_exit_reaches_terminal_status`) runs the scenario 10 times to account for the timing-dependent nature of the race, asserting the service always reaches `exited` status.

## How to Test ?

Run the new e2e regression test:

```
cargo test test_instant_exit_reaches_terminal_status
```